### PR TITLE
feat(core): truncate tool results before compaction

### DIFF
--- a/crates/core/src/agent/compact.rs
+++ b/crates/core/src/agent/compact.rs
@@ -1,6 +1,6 @@
 //! Context compaction — summarize conversation history and replace it.
 
-use crate::model::{Message, Model, Request};
+use crate::model::{Message, Model, Request, Role};
 
 pub(crate) const COMPACT_PROMPT: &str = include_str!("../../prompts/compact.md");
 
@@ -29,7 +29,14 @@ impl<M: Model> super::Agent<M> {
                 self.config.system_prompt
             )));
         }
-        messages.extend(history.iter().cloned());
+        let max_len = self.config.compact_tool_max_len;
+        messages.extend(history.iter().cloned().map(|mut m| {
+            if m.role == Role::Tool && m.content.len() > max_len {
+                m.content.truncate(m.content.floor_char_boundary(max_len));
+                m.content.push_str("... [truncated]");
+            }
+            m
+        }));
 
         let request = Request::new(model_name).with_messages(messages);
         match self.model.send(&request).await {

--- a/crates/core/src/agent/config.rs
+++ b/crates/core/src/agent/config.rs
@@ -12,6 +12,9 @@ const DEFAULT_MAX_ITERATIONS: usize = 16;
 /// Default compact threshold in estimated tokens (~100k).
 const DEFAULT_COMPACT_THRESHOLD: usize = 100_000;
 
+/// Default max byte length for tool results during compaction.
+const DEFAULT_COMPACT_TOOL_MAX_LEN: usize = 1024;
+
 /// Serializable agent configuration.
 ///
 /// Contains all parameters for an agent: identity, system prompt, model,
@@ -57,6 +60,10 @@ pub struct AgentConfig {
     /// None = disabled. Defaults to 100_000.
     #[serde(default = "default_compact_threshold")]
     pub compact_threshold: Option<usize>,
+    /// Max byte length to keep from tool-role messages when compacting.
+    /// Longer results are truncated before sending to the compaction LLM.
+    #[serde(default = "default_compact_tool_max_len")]
+    pub compact_tool_max_len: usize,
 }
 
 fn default_max_iterations() -> usize {
@@ -65,6 +72,10 @@ fn default_max_iterations() -> usize {
 
 fn default_compact_threshold() -> Option<usize> {
     Some(DEFAULT_COMPACT_THRESHOLD)
+}
+
+fn default_compact_tool_max_len() -> usize {
+    DEFAULT_COMPACT_TOOL_MAX_LEN
 }
 
 impl Default for AgentConfig {
@@ -82,6 +93,7 @@ impl Default for AgentConfig {
             mcps: Vec::new(),
             tools: Vec::new(),
             compact_threshold: default_compact_threshold(),
+            compact_tool_max_len: DEFAULT_COMPACT_TOOL_MAX_LEN,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add `compact_tool_max_len` field to `AgentConfig` (default 1024 bytes) to control how much tool-result content is sent to the compaction LLM
- In `Agent::compact()`, truncate `Role::Tool` messages exceeding the limit at a safe UTF-8 boundary before sending to the LLM
- Avoids processing 200KB+ tool outputs just to summarize "the user ran a build"

## Phases completed

- [x] Phase 1: Add config field + truncation logic in `compact()`

Closes #91