### PR TITLE
chore: bump workspace version to 0.0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["apps/*", "crates/*"]
 
 [workspace.package]
-version = "0.0.15"
+version = "0.0.16"
 edition = "2024"
 authors = ["clearloop <tianyi.gc@gmail.com>"]
 license = "MIT OR Apache-2.0"
@@ -11,20 +11,20 @@ repository = "https://github.com/crabtalk/crabtalk"
 keywords = ["llm", "agent", "ai"]
 
 [workspace.dependencies]
-crabhub = { path = "apps/hub", package = "crabhub", version = "0.0.15" }
-crabtalk-telegram = { path = "apps/telegram", version = "0.0.15" }
-crabtalk-wechat = { path = "apps/wechat", version = "0.0.15" }
-gateway = { path = "crates/gateway", package = "crabtalk-gateway", version = "0.0.15" }
-cli = { path = "crates/cli", package = "crabtalk", version = "0.0.15" }
-daemon = { path = "crates/daemon", package = "crabtalk-daemon", version = "0.0.15" }
-runtime = { path = "crates/runtime", package = "crabtalk-runtime", version = "0.0.15" }
-model = { path = "crates/model", package = "crabtalk-model", version = "0.0.15" }
-transport = { path = "crates/transport", package = "crabtalk-transport", version = "0.0.15" }
-wcore = { path = "crates/core", package = "crabtalk-core", version = "0.0.15" }
-crabtalk-command = { path = "crates/command", version = "0.0.15" }
-crabtalk-command-codegen = { path = "crates/command-codegen", version = "0.0.15" }
-woutlook = { path = "apps/outlook", package = "crabtalk-outlook", version = "0.0.15", default-features = false }
-wsearch = { path = "apps/search", package = "crabtalk-search", version = "0.0.15", default-features = false }
+crabhub = { path = "apps/hub", package = "crabhub", version = "0.0.16" }
+crabtalk-telegram = { path = "apps/telegram", version = "0.0.16" }
+crabtalk-wechat = { path = "apps/wechat", version = "0.0.16" }
+gateway = { path = "crates/gateway", package = "crabtalk-gateway", version = "0.0.16" }
+cli = { path = "crates/cli", package = "crabtalk", version = "0.0.16" }
+daemon = { path = "crates/daemon", package = "crabtalk-daemon", version = "0.0.16" }
+runtime = { path = "crates/runtime", package = "crabtalk-runtime", version = "0.0.16" }
+model = { path = "crates/model", package = "crabtalk-model", version = "0.0.16" }
+transport = { path = "crates/transport", package = "crabtalk-transport", version = "0.0.16" }
+wcore = { path = "crates/core", package = "crabtalk-core", version = "0.0.16" }
+crabtalk-command = { path = "crates/command", version = "0.0.16" }
+crabtalk-command-codegen = { path = "crates/command-codegen", version = "0.0.16" }
+woutlook = { path = "apps/outlook", package = "crabtalk-outlook", version = "0.0.16", default-features = false }
+wsearch = { path = "apps/search", package = "crabtalk-search", version = "0.0.16", default-features = false }
 
 # crabllm
 crabllm-core = "0.0.10"


### PR DESCRIPTION
## Summary

- Bump all 14 workspace crate versions from 0.0.15 to 0.0.16

## Test plan

- `cargo check --workspace` passes