### PR TITLE
feat(runtime): topic switching as a first-class conversation boundary

### DIFF
--- a/crates/core/src/config/node.rs
+++ b/crates/core/src/config/node.rs
@@ -1,11 +1,10 @@
 //! Node configuration loaded from `config.toml`.
 
+use super::system::SystemConfig;
 use crate::{McpServerConfig, ProviderDef, config::DisabledItems};
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
-
-use super::system::SystemConfig;
 
 /// Top-level node configuration (`config.toml`).
 ///

--- a/crates/core/src/storage.rs
+++ b/crates/core/src/storage.rs
@@ -155,6 +155,11 @@ pub struct ConversationMeta {
     pub title: String,
     #[serde(default)]
     pub uptime_secs: u64,
+    /// Topic this conversation belongs to, if any. `None` means the
+    /// conversation is a tmp chat and should not have been persisted —
+    /// only topic-bound conversations reach the Storage layer.
+    #[serde(default)]
+    pub topic: Option<String>,
 }
 
 /// A trace entry persisted alongside messages.

--- a/crates/core/src/testing/mem.rs
+++ b/crates/core/src/testing/mem.rs
@@ -80,6 +80,7 @@ impl Storage for InMemoryStorage {
                 created_at: chrono::Utc::now().to_rfc3339(),
                 title: String::new(),
                 uptime_secs: 0,
+                topic: None,
             },
             messages: Vec::new(),
             events: Vec::new(),

--- a/crates/core/src/testing/mod.rs
+++ b/crates/core/src/testing/mod.rs
@@ -5,11 +5,10 @@
 //! for a minimal [`Tool`] schema.
 
 use crabllm_core::{FunctionDef, Tool, ToolType};
+pub use mem::InMemoryStorage;
 
 mod mem;
 pub mod provider;
-
-pub use mem::InMemoryStorage;
 
 /// Create a minimal tool schema for testing.
 pub fn test_schema(name: &str) -> Tool {

--- a/crates/crabtalk/prompts/topic.md
+++ b/crates/crabtalk/prompts/topic.md
@@ -1,0 +1,36 @@
+## Topics
+
+You can split your work with a person into parallel threads called
+**topics**. Each topic is its own conversation with its own history and
+its own compaction archive — so work on one project doesn't clutter the
+context you're holding for another.
+
+You have two tools: `search_topics` (BM25-search existing topics) and
+`switch_topic` (resume a topic, or create a new one — `description`
+required on create and becomes what search indexes).
+
+### When to switch
+
+The first message of every conversation lands in a tmp chat — no topic,
+not persisted, gone at the end of the run. Switch into a topic when
+the human names identifiable ongoing work (a project, an investigation,
+a codebase). Otherwise stay in tmp. Call `search_topics` before creating
+— you may already have a topic for this.
+
+### Titles and descriptions
+
+- **Title** is the key. Free-form, agent-chosen, immutable. Pick
+  something you'd recognize six months later: `auth-refactor`, not
+  `refactor`.
+- **Description** is one to three sentences naming the scope. Written
+  once at creation. If the focus shifts significantly, that's a signal
+  to switch into a new topic, not to rewrite the label.
+
+### Interaction with compaction and recall
+
+Each topic compacts independently. Its archives are named
+`{topic-slug}-1`, `{topic-slug}-2`, …, so a long-running topic's earlier
+phases stay searchable via `recall` instead of getting overwritten.
+`recall` spans everything (notes, archives, topics). `search_topics` is
+the narrower tool — use it when you specifically want to know *what
+threads exist*.

--- a/crates/crabtalk/src/daemon/builder.rs
+++ b/crates/crabtalk/src/daemon/builder.rs
@@ -189,9 +189,7 @@ impl<P: Provider + 'static> Daemon<P> {
         .await?;
         {
             let old_runtime = self.runtime.read().await;
-            (**old_runtime)
-                .transfer_conversations(&mut new_runtime)
-                .await;
+            (**old_runtime).transfer_to(&mut new_runtime).await;
         }
         {
             let events_for_sink = self.events.clone();

--- a/crates/crabtalk/src/daemon/builder.rs
+++ b/crates/crabtalk/src/daemon/builder.rs
@@ -319,6 +319,14 @@ impl<P: Provider + 'static> Daemon<P> {
         );
 
         node_hook.register_hook(
+            "topic",
+            Arc::new(crate::hooks::topic::TopicHook::<P>::new(
+                runtime_once.clone(),
+                shared_memory.clone(),
+            )),
+        );
+
+        node_hook.register_hook(
             "skill",
             Arc::new(crate::hooks::skill::handler::SkillHook::new(
                 storage,

--- a/crates/crabtalk/src/hooks/delegate.rs
+++ b/crates/crabtalk/src/hooks/delegate.rs
@@ -255,7 +255,7 @@ fn spawn_agent_task<P: Provider + 'static>(
 
         conversation_cwds.lock().await.remove(&conversation_id);
         read_files.lock().remove(&conversation_id);
-        rt.close_conversation(conversation_id).await;
+        rt.close(conversation_id).await;
 
         (result_content, error_msg)
     })

--- a/crates/crabtalk/src/hooks/memory/mod.rs
+++ b/crates/crabtalk/src/hooks/memory/mod.rs
@@ -4,8 +4,11 @@
 //! for the design.
 
 use anyhow::Result;
+use forget::Forget;
 use memory::Memory as Store;
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use recall::Recall;
+use remember::Remember;
 use runtime::Hook;
 use std::{path::PathBuf, sync::Arc};
 use wcore::{
@@ -17,10 +20,6 @@ use wcore::{
 mod forget;
 mod recall;
 mod remember;
-
-use forget::Forget;
-use recall::Recall;
-use remember::Remember;
 
 /// Shared handle to the underlying memory store. Cloneable because the
 /// runtime needs a reference of its own for writing archives during

--- a/crates/crabtalk/src/hooks/mod.rs
+++ b/crates/crabtalk/src/hooks/mod.rs
@@ -5,5 +5,6 @@ pub mod delegate;
 pub mod memory;
 pub mod os;
 pub mod skill;
+pub mod topic;
 
 pub use memory::Memory;

--- a/crates/crabtalk/src/hooks/os/bash/mod.rs
+++ b/crates/crabtalk/src/hooks/os/bash/mod.rs
@@ -1,11 +1,11 @@
 //! Bash tool — schema definition.
 
-pub(super) mod config;
-mod handler;
-
 use schemars::JsonSchema;
 use serde::Deserialize;
 use std::collections::BTreeMap;
+
+pub(super) mod config;
+mod handler;
 
 /// Run a shell command.
 #[derive(Deserialize, JsonSchema)]

--- a/crates/crabtalk/src/hooks/topic/mod.rs
+++ b/crates/crabtalk/src/hooks/topic/mod.rs
@@ -2,7 +2,7 @@
 //! `(agent, sender)` into parallel conversation threads; see RFC #171.
 //!
 //! The hook itself owns no state — it holds a late-bind runtime handle
-//! (to drive `switch_active_topic`) and a shared memory handle (to BM25
+//! (to drive `switch_topic`) and a shared memory handle (to BM25
 //! over `EntryKind::Topic` entries).
 
 use crabllm_core::Provider;

--- a/crates/crabtalk/src/hooks/topic/mod.rs
+++ b/crates/crabtalk/src/hooks/topic/mod.rs
@@ -1,0 +1,44 @@
+//! Topic hook — `search_topics` and `switch_topic`. Topics partition
+//! `(agent, sender)` into parallel conversation threads; see RFC #171.
+//!
+//! The hook itself owns no state — it holds a late-bind runtime handle
+//! (to drive `switch_active_topic`) and a shared memory handle (to BM25
+//! over `EntryKind::Topic` entries).
+
+use crabllm_core::Provider;
+use runtime::{Hook, SharedMemory};
+use std::sync::{Arc, OnceLock};
+use wcore::{ToolDispatch, ToolFuture, agent::AsTool, model::Tool};
+
+use crate::daemon::SharedRuntime;
+
+mod search;
+mod switch;
+
+use search::SearchTopics;
+use switch::SwitchTopic;
+
+pub struct TopicHook<P: Provider + 'static> {
+    pub(super) runtime: Arc<OnceLock<SharedRuntime<P>>>,
+    pub(super) memory: SharedMemory,
+}
+
+impl<P: Provider + 'static> TopicHook<P> {
+    pub fn new(runtime: Arc<OnceLock<SharedRuntime<P>>>, memory: SharedMemory) -> Self {
+        Self { runtime, memory }
+    }
+}
+
+impl<P: Provider + 'static> Hook for TopicHook<P> {
+    fn schema(&self) -> Vec<Tool> {
+        vec![SearchTopics::as_tool(), SwitchTopic::as_tool()]
+    }
+
+    fn dispatch<'a>(&'a self, name: &'a str, call: ToolDispatch) -> Option<ToolFuture<'a>> {
+        match name {
+            "search_topics" => Some(Box::pin(self.handle_search_topics(call))),
+            "switch_topic" => Some(Box::pin(self.handle_switch_topic(call))),
+            _ => None,
+        }
+    }
+}

--- a/crates/crabtalk/src/hooks/topic/mod.rs
+++ b/crates/crabtalk/src/hooks/topic/mod.rs
@@ -5,18 +5,16 @@
 //! (to drive `switch_topic`) and a shared memory handle (to BM25
 //! over `EntryKind::Topic` entries).
 
+use crate::daemon::SharedRuntime;
 use crabllm_core::Provider;
 use runtime::{Hook, SharedMemory};
+use search::SearchTopics;
 use std::sync::{Arc, OnceLock};
+use switch::SwitchTopic;
 use wcore::{ToolDispatch, ToolFuture, agent::AsTool, model::Tool};
-
-use crate::daemon::SharedRuntime;
 
 mod search;
 mod switch;
-
-use search::SearchTopics;
-use switch::SwitchTopic;
 
 /// Behavioural guidance — when/how to use the topic tools. Tool
 /// *signatures* come from each struct's `///` doc comment via schemars.

--- a/crates/crabtalk/src/hooks/topic/mod.rs
+++ b/crates/crabtalk/src/hooks/topic/mod.rs
@@ -18,6 +18,10 @@ mod switch;
 use search::SearchTopics;
 use switch::SwitchTopic;
 
+/// Behavioural guidance — when/how to use the topic tools. Tool
+/// *signatures* come from each struct's `///` doc comment via schemars.
+const TOPIC_PROMPT: &str = include_str!("../../../prompts/topic.md");
+
 pub struct TopicHook<P: Provider + 'static> {
     pub(super) runtime: Arc<OnceLock<SharedRuntime<P>>>,
     pub(super) memory: SharedMemory,
@@ -32,6 +36,10 @@ impl<P: Provider + 'static> TopicHook<P> {
 impl<P: Provider + 'static> Hook for TopicHook<P> {
     fn schema(&self) -> Vec<Tool> {
         vec![SearchTopics::as_tool(), SwitchTopic::as_tool()]
+    }
+
+    fn system_prompt(&self) -> Option<String> {
+        Some(format!("\n\n{TOPIC_PROMPT}"))
     }
 
     fn dispatch<'a>(&'a self, name: &'a str, call: ToolDispatch) -> Option<ToolFuture<'a>> {

--- a/crates/crabtalk/src/hooks/topic/search.rs
+++ b/crates/crabtalk/src/hooks/topic/search.rs
@@ -1,0 +1,36 @@
+//! `search_topics` — BM25 search restricted to `EntryKind::Topic`.
+
+use super::TopicHook;
+use crabllm_core::Provider;
+use memory::EntryKind;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use wcore::ToolDispatch;
+
+/// Search your existing topics by keyword. Returns ranked
+/// `(title, description)` pairs.
+#[derive(Deserialize, JsonSchema)]
+pub struct SearchTopics {
+    /// Keyword or phrase to match against topic titles/descriptions.
+    pub query: String,
+    /// Maximum number of results to return. Defaults to 5.
+    pub limit: Option<usize>,
+}
+
+impl<P: Provider + 'static> TopicHook<P> {
+    pub(super) async fn handle_search_topics(&self, call: ToolDispatch) -> Result<String, String> {
+        let input: SearchTopics =
+            serde_json::from_str(&call.args).map_err(|e| format!("invalid arguments: {e}"))?;
+        let limit = input.limit.unwrap_or(5);
+        let store = self.memory.read();
+        let hits = store.search_kind(&input.query, limit, EntryKind::Topic);
+        if hits.is_empty() {
+            return Ok("no topics found".to_owned());
+        }
+        Ok(hits
+            .iter()
+            .map(|h| format!("## {}\n{}", h.entry.name, h.entry.content))
+            .collect::<Vec<_>>()
+            .join("\n---\n"))
+    }
+}

--- a/crates/crabtalk/src/hooks/topic/switch.rs
+++ b/crates/crabtalk/src/hooks/topic/switch.rs
@@ -34,7 +34,7 @@ impl<P: Provider + 'static> TopicHook<P> {
             .ok_or_else(|| "switch_topic: runtime not initialized".to_owned())?;
         let rt = shared.read().await.clone();
         let outcome = rt
-            .switch_active_topic(
+            .switch_topic(
                 &call.agent,
                 &call.sender,
                 &input.title,

--- a/crates/crabtalk/src/hooks/topic/switch.rs
+++ b/crates/crabtalk/src/hooks/topic/switch.rs
@@ -1,0 +1,51 @@
+//! `switch_topic` — enter an existing topic or create a new one. On
+//! create, writes an `EntryKind::Topic` memory entry so the topic is
+//! searchable. On resume, flips the active-topic pointer for the
+//! current `(agent, sender)`.
+
+use super::TopicHook;
+use crabllm_core::Provider;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use wcore::ToolDispatch;
+
+/// Switch the active topic for this conversation. Exact title match
+/// resumes that topic; a new title creates a fresh one (requires
+/// `description`). Untopicked chats are tmp and not persisted —
+/// entering a topic is how the agent promotes work into long-term
+/// memory.
+#[derive(Deserialize, JsonSchema)]
+pub struct SwitchTopic {
+    /// Topic title. Free-form; the title is the key.
+    pub title: String,
+    /// One- to three-sentence description of the topic. Required when
+    /// creating a new topic; ignored when resuming an existing one.
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+impl<P: Provider + 'static> TopicHook<P> {
+    pub(super) async fn handle_switch_topic(&self, call: ToolDispatch) -> Result<String, String> {
+        let input: SwitchTopic =
+            serde_json::from_str(&call.args).map_err(|e| format!("invalid arguments: {e}"))?;
+        let shared = self
+            .runtime
+            .get()
+            .ok_or_else(|| "switch_topic: runtime not initialized".to_owned())?;
+        let rt = shared.read().await.clone();
+        let outcome = rt
+            .switch_active_topic(
+                &call.agent,
+                &call.sender,
+                &input.title,
+                input.description.as_deref(),
+            )
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(if outcome.resumed {
+            format!("resumed topic: {}", input.title)
+        } else {
+            format!("created topic: {}", input.title)
+        })
+    }
+}

--- a/crates/crabtalk/src/mcp/client/mod.rs
+++ b/crates/crabtalk/src/mcp/client/mod.rs
@@ -4,7 +4,6 @@
 //! `initialize`, `tools/list`, and `tools/call`.
 
 use anyhow::{Context, Result};
-
 pub use jsonrpc::{CallToolResult, ContentItem, McpTool};
 use jsonrpc::{ClientInfo, InitializeParams, ListToolsResult};
 

--- a/crates/crabtalk/src/protocol/conversation.rs
+++ b/crates/crabtalk/src/protocol/conversation.rs
@@ -178,13 +178,10 @@ pub(super) async fn compact<P: Provider + 'static>(
     sender: String,
 ) -> Result<String> {
     let rt = node.runtime.read().await.clone();
-    let conversation_id = rt
-        .find_conversation_id(&agent, &sender)
-        .await
-        .ok_or_else(|| {
-            anyhow::anyhow!("conversation not found for agent='{agent}' sender='{sender}'")
-        })?;
-    rt.compact_conversation(conversation_id)
+    let conversation_id = rt.conversation_id(&agent, &sender).await.ok_or_else(|| {
+        anyhow::anyhow!("conversation not found for agent='{agent}' sender='{sender}'")
+    })?;
+    rt.compact(conversation_id)
         .await
         .ok_or_else(|| anyhow::anyhow!("compact failed for agent='{agent}' sender='{sender}'"))
 }
@@ -193,7 +190,7 @@ pub(super) async fn list_active<P: Provider + 'static>(
     node: &Daemon<P>,
 ) -> Result<Vec<wcore::protocol::message::ActiveConversationInfo>> {
     let rt = node.runtime.read().await.clone();
-    Ok(rt.active_conversation_infos().await)
+    Ok(rt.list_active().await)
 }
 
 pub(super) async fn kill<P: Provider + 'static>(
@@ -202,7 +199,7 @@ pub(super) async fn kill<P: Provider + 'static>(
     sender: String,
 ) -> Result<bool> {
     let rt = node.runtime.read().await.clone();
-    let Some(conversation_id) = rt.find_conversation_id(&agent, &sender).await else {
+    let Some(conversation_id) = rt.conversation_id(&agent, &sender).await else {
         return Ok(false);
     };
     node.os_hook
@@ -210,7 +207,7 @@ pub(super) async fn kill<P: Provider + 'static>(
         .lock()
         .await
         .remove(&conversation_id);
-    Ok(rt.close_conversation(conversation_id).await)
+    Ok(rt.close(conversation_id).await)
 }
 
 pub(super) async fn reply_to_ask<P: Provider + 'static>(
@@ -220,12 +217,9 @@ pub(super) async fn reply_to_ask<P: Provider + 'static>(
     content: String,
 ) -> Result<()> {
     let rt = node.runtime.read().await.clone();
-    let conversation_id = rt
-        .find_conversation_id(&agent, &sender)
-        .await
-        .ok_or_else(|| {
-            anyhow::anyhow!("conversation not found for agent='{agent}' sender='{sender}'")
-        })?;
+    let conversation_id = rt.conversation_id(&agent, &sender).await.ok_or_else(|| {
+        anyhow::anyhow!("conversation not found for agent='{agent}' sender='{sender}'")
+    })?;
     if let Some(tx) = node
         .ask_hook
         .pending_asks()
@@ -263,7 +257,7 @@ pub(super) async fn steer<P: Provider + 'static>(
         &req.sender
     };
     let conversation_id = rt
-        .find_conversation_id(&req.agent, sender)
+        .conversation_id(&req.agent, sender)
         .await
         .ok_or_else(|| {
             anyhow::anyhow!(

--- a/crates/crabtalk/src/storage/fs.rs
+++ b/crates/crabtalk/src/storage/fs.rs
@@ -218,6 +218,7 @@ impl Storage for FsStorage {
             created_at: chrono::Utc::now().to_rfc3339(),
             title: String::new(),
             uptime_secs: 0,
+            topic: None,
         };
         let meta_bytes = serde_json::to_vec(&meta)?;
         atomic_write(&self.session_meta_path(&slug), &meta_bytes)?;

--- a/crates/crabtalk/src/storage/mod.rs
+++ b/crates/crabtalk/src/storage/mod.rs
@@ -3,19 +3,18 @@
 //! [`FsStorage`] implements [`Storage`](wcore::storage::Storage)
 //! with TOML configs, markdown prompts, and JSON session files.
 
-mod backfill;
-mod fs;
-mod loader;
-
 pub use self::fs::FsStorage;
 pub use backfill::{backfill_local_agent_ids, migrate_local_agent_prompts};
 pub use loader::{DEFAULT_CONFIG, scaffold_config_dir};
-
 use std::{
     fs as stdfs,
     path::{Path, PathBuf},
     time::{SystemTime, UNIX_EPOCH},
 };
+
+mod backfill;
+mod fs;
+mod loader;
 
 /// Atomic write: same-directory tmp file + rename.
 pub fn atomic_write(path: &Path, data: &[u8]) -> anyhow::Result<()> {

--- a/crates/memory/src/dump.rs
+++ b/crates/memory/src/dump.rs
@@ -6,6 +6,7 @@
 //!   SUMMARY.md                ← auto-generated mdbook ToC (ignored on load)
 //!   notes/{name}.md           ← EntryKind::Note
 //!   archives/{name}.md        ← EntryKind::Archive
+//!   topics/{name}.md          ← EntryKind::Topic
 //! ```
 //!
 //! Entry file format: an HTML metadata block at the top, then the
@@ -49,6 +50,7 @@ use std::{collections::HashMap, fs, path::Path};
 pub(crate) const KIND_SECTIONS: &[(EntryKind, &str, &str)] = &[
     (EntryKind::Note, "notes", "Notes"),
     (EntryKind::Archive, "archives", "Archives"),
+    (EntryKind::Topic, "topics", "Topics"),
 ];
 
 const META_OPEN: &str = "<div id=\"meta\">";

--- a/crates/memory/src/entry.rs
+++ b/crates/memory/src/entry.rs
@@ -4,6 +4,7 @@ pub type EntryId = u64;
 pub enum EntryKind {
     Note,
     Archive,
+    Topic,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/memory/src/file.rs
+++ b/crates/memory/src/file.rs
@@ -17,7 +17,7 @@
 //! ```text
 //!   id          u64 LE
 //!   created_at  u64 LE
-//!   kind        u32 LE    (0 = Note, 1 = Archive)
+//!   kind        u32 LE    (0 = Note, 1 = Archive, 2 = Topic)
 //!   name        u32 len LE + utf8 bytes
 //!   content     u32 len LE + utf8 bytes
 //!   alias_cnt   u32 LE
@@ -42,10 +42,13 @@ use std::{
 };
 
 const MAGIC: &[u8; 6] = b"CRMEM\0";
+// Bump when a new kind ships post-1.0 so older binaries refuse files
+// they can't interpret instead of crashing on "unknown entry kind".
 const VERSION: u32 = 1;
 const HEADER_LEN: usize = 16;
 const KIND_NOTE: u32 = 0;
 const KIND_ARCHIVE: u32 = 1;
+const KIND_TOPIC: u32 = 2;
 
 pub(crate) struct Snapshot {
     pub(crate) next_id: EntryId,
@@ -130,6 +133,7 @@ fn encode_entry(buf: &mut Vec<u8>, e: &Entry) -> Result<()> {
     let kind = match e.kind {
         EntryKind::Note => KIND_NOTE,
         EntryKind::Archive => KIND_ARCHIVE,
+        EntryKind::Topic => KIND_TOPIC,
     };
     buf.extend_from_slice(&kind.to_le_bytes());
     encode_string(buf, &e.name)?;
@@ -192,6 +196,7 @@ impl<'a> Cursor<'a> {
         let kind = match self.read_u32()? {
             KIND_NOTE => EntryKind::Note,
             KIND_ARCHIVE => EntryKind::Archive,
+            KIND_TOPIC => EntryKind::Topic,
             _ => return Err(Error::BadFormat("unknown entry kind")),
         };
         let name = self.read_string()?;

--- a/crates/memory/src/memory.rs
+++ b/crates/memory/src/memory.rs
@@ -114,6 +114,30 @@ impl Memory {
             .collect()
     }
 
+    /// BM25 search restricted to a single `EntryKind`. The inner search
+    /// runs unbounded so the kind filter can't truncate matches mid-list;
+    /// we clone only the survivors that fit inside `limit`.
+    pub fn search_kind(&self, query: &str, limit: usize, kind: EntryKind) -> Vec<SearchHit> {
+        if limit == 0 {
+            return Vec::new();
+        }
+        self.index
+            .search(query, usize::MAX)
+            .into_iter()
+            .filter_map(|(id, score)| {
+                let entry = self.entries.get(&id)?;
+                if entry.kind != kind {
+                    return None;
+                }
+                Some(SearchHit {
+                    entry: entry.clone(),
+                    score,
+                })
+            })
+            .take(limit)
+            .collect()
+    }
+
     fn add(
         &mut self,
         name: String,

--- a/crates/runtime/README.md
+++ b/crates/runtime/README.md
@@ -1,11 +1,12 @@
 # crabtalk-runtime
 
-Agent runtime — tool dispatch, MCP bridge, skills, memory, and session management.
+Agent runtime — agent registry, conversation management, and hook orchestration.
 
-Provides `Session` for stateful agent execution, `McpBridge` for connecting to
-MCP servers (stdio and HTTP transports), `SkillRegistry` for loading skill
-directories, and `MemoryStore` for agent memory. Includes an inline MCP client
-that implements `initialize`, `tools/list`, and `tools/call` over JSON-RPC 2.0.
+Exposes `Runtime<C>` (the main entry point), `Conversation` (in-memory
+conversation state), and the `Env` and `Hook` traits used to extend the runtime
+with tools, event sinks, and environment-specific behavior. Persistence is
+delegated to the `Storage` trait from `crabtalk-core`; memory is delegated to
+`crabtalk-memory` via `SharedMemory`.
 
 ## License
 

--- a/crates/runtime/src/conversation.rs
+++ b/crates/runtime/src/conversation.rs
@@ -27,7 +27,7 @@ pub struct Conversation {
     /// that never enter a topic.
     pub handle: Option<SessionHandle>,
     /// Topic this conversation belongs to, if any. `None` = tmp chat
-    /// (no storage, no resume). Set by `switch_active_topic`.
+    /// (no storage, no resume). Set by `switch_topic`.
     pub topic: Option<String>,
 }
 

--- a/crates/runtime/src/conversation.rs
+++ b/crates/runtime/src/conversation.rs
@@ -23,8 +23,12 @@ pub struct Conversation {
     /// When this conversation was loaded/created in this process.
     pub created_at: Instant,
     /// Persistent session identity, assigned by the repo. `None` until
-    /// the first persistence call.
+    /// the first persistence call — and remains `None` for tmp chats
+    /// that never enter a topic.
     pub handle: Option<SessionHandle>,
+    /// Topic this conversation belongs to, if any. `None` = tmp chat
+    /// (no storage, no resume). Set by `switch_active_topic`.
+    pub topic: Option<String>,
 }
 
 impl Conversation {
@@ -37,6 +41,7 @@ impl Conversation {
             uptime_secs: 0,
             created_at: Instant::now(),
             handle: None,
+            topic: None,
         }
     }
 
@@ -49,6 +54,7 @@ impl Conversation {
             created_at: chrono::Utc::now().to_rfc3339(),
             title: self.title.clone(),
             uptime_secs: self.uptime_secs,
+            topic: self.topic.clone(),
         }
     }
 }

--- a/crates/runtime/src/conversation.rs
+++ b/crates/runtime/src/conversation.rs
@@ -1,10 +1,8 @@
 //! Conversation — pure working-context container.
 
+use crate::ConversationHandle;
 use std::time::Instant;
-use wcore::{
-    model::HistoryEntry,
-    storage::{ConversationMeta, SessionHandle},
-};
+use wcore::{model::HistoryEntry, storage::ConversationMeta};
 
 /// A conversation tied to a specific agent.
 ///
@@ -22,10 +20,10 @@ pub struct Conversation {
     pub uptime_secs: u64,
     /// When this conversation was loaded/created in this process.
     pub created_at: Instant,
-    /// Persistent session identity, assigned by the repo. `None` until
-    /// the first persistence call — and remains `None` for tmp chats
-    /// that never enter a topic.
-    pub handle: Option<SessionHandle>,
+    /// Persistent conversation identity, assigned by the storage layer.
+    /// `None` until the first persistence call — and remains `None` for
+    /// tmp chats that never enter a topic.
+    pub handle: Option<ConversationHandle>,
     /// Topic this conversation belongs to, if any. `None` = tmp chat
     /// (no storage, no resume). Set by `switch_topic`.
     pub topic: Option<String>,

--- a/crates/runtime/src/engine/agents.rs
+++ b/crates/runtime/src/engine/agents.rs
@@ -1,10 +1,9 @@
 //! Agent registry — persistent and ephemeral agent management.
 
+use super::Runtime;
 use crate::{Config, Env, Hook};
 use std::sync::Arc;
 use wcore::{Agent, AgentBuilder, AgentConfig, ToolDispatcher};
-
-use super::Runtime;
 
 impl<C: Config> Runtime<C> {
     pub fn add_agent(&self, config: AgentConfig) {

--- a/crates/runtime/src/engine/conversation.rs
+++ b/crates/runtime/src/engine/conversation.rs
@@ -11,7 +11,7 @@ use wcore::{
     storage::{SessionHandle, Storage},
 };
 
-use super::{ConvSlot, Runtime};
+use super::{ConvSlot, Runtime, TopicRouter};
 
 /// Outcome of `switch_active_topic`. `resumed = true` means the topic
 /// already existed (in the router or on disk); `false` means it was
@@ -49,17 +49,14 @@ impl<C: Config> Runtime<C> {
         // Read-first: the common case is a hit on an existing tmp or
         // active-topic conversation. Avoid allocating a `TopicRouter`
         // until we actually need to insert one.
+        if let Some(id) = self
+            .topics
+            .read()
+            .await
+            .get(&key)
+            .and_then(TopicRouter::active_conversation)
         {
-            let topics = self.topics.read().await;
-            if let Some(router) = topics.get(&key)
-                && let Some(id) = router
-                    .active
-                    .as_ref()
-                    .and_then(|t| router.by_title.get(t).copied())
-                    .or(router.tmp)
-            {
-                return Ok(id);
-            }
+            return Ok(id);
         }
 
         let id = self.next_conversation_id.fetch_add(1, Ordering::Relaxed);
@@ -67,12 +64,7 @@ impl<C: Config> Runtime<C> {
         let mut topics = self.topics.write().await;
         let router = topics.entry(key).or_default();
         // Re-check under write lock in case another task raced us.
-        if let Some(existing) = router
-            .active
-            .as_ref()
-            .and_then(|t| router.by_title.get(t).copied())
-            .or(router.tmp)
-        {
+        if let Some(existing) = router.active_conversation() {
             return Ok(existing);
         }
         router.tmp = Some(id);
@@ -176,18 +168,9 @@ impl<C: Config> Runtime<C> {
                     // Stamp meta so the new session carries its topic
                     // from the first write — a missing `topic` here
                     // would make the session invisible to future
-                    // `find_topic_session` scans.
-                    storage.update_session_meta(
-                        &handle,
-                        &wcore::storage::ConversationMeta {
-                            agent: agent.to_owned(),
-                            created_by: sender.to_owned(),
-                            created_at: chrono::Utc::now().to_rfc3339(),
-                            title: String::new(),
-                            uptime_secs: 0,
-                            topic: Some(title.to_owned()),
-                        },
-                    )?;
+                    // `find_topic_session` scans. `conversation.meta`
+                    // already reflects the topic we set above.
+                    storage.update_session_meta(&handle, &conversation.meta(agent, sender))?;
                     conversation.handle = Some(handle);
                 }
             }
@@ -347,6 +330,21 @@ impl<C: Config> Runtime<C> {
             .map(|slot| slot.inner.clone())
     }
 
+    /// Look up a conversation slot's `(agent, sender, mutex)` triple.
+    /// Returns `None` when the conversation id is not registered — the
+    /// execution paths all need this handshake before locking the
+    /// conversation mutex.
+    pub(crate) async fn acquire_slot(
+        &self,
+        id: u64,
+    ) -> Option<(String, String, Arc<Mutex<Conversation>>)> {
+        self.conversations
+            .read()
+            .await
+            .get(&id)
+            .map(ConvSlot::parts)
+    }
+
     pub async fn conversations(&self) -> Vec<Arc<Mutex<Conversation>>> {
         self.conversations
             .read()
@@ -383,17 +381,10 @@ impl<C: Config> Runtime<C> {
             }
             (agent_name, conversation.history.clone())
         };
-        let persistent = self.agents.read().get(&agent_name).cloned();
-        if let Some(a) = persistent {
-            return a.compact(&history).await;
-        }
-        let a = self
-            .ephemeral_agents
-            .read()
+        self.resolve_agent(&agent_name)
+            .await?
+            .compact(&history)
             .await
-            .get(&agent_name)
-            .cloned()?;
-        a.compact(&history).await
     }
 
     pub async fn transfer_conversations<C2: Config>(&self, dest: &mut Runtime<C2>) {
@@ -484,6 +475,36 @@ impl<C: Config> Runtime<C> {
         match storage.create_session(agent, created_by) {
             Ok(handle) => conversation.handle = Some(handle),
             Err(e) => tracing::warn!("failed to create session: {e}"),
+        }
+    }
+
+    /// Post-run tail shared by `send_to`, `stream_to`, and
+    /// `guest_stream_to`: update uptime, persist, and kick off title
+    /// generation if the conversation has a titleable exchange and no
+    /// title yet.
+    pub(crate) fn finalize_run(
+        &self,
+        conversation_id: u64,
+        conversation: &mut Conversation,
+        conversation_mutex: Arc<Mutex<Conversation>>,
+        agent: &str,
+        created_by: &str,
+        run_start: std::time::Instant,
+        pre_run_len: usize,
+        compact_summary: Option<String>,
+        event_trace: &[wcore::EventLine],
+    ) {
+        conversation.uptime_secs += run_start.elapsed().as_secs();
+        self.persist_messages(
+            conversation,
+            agent,
+            created_by,
+            pre_run_len,
+            compact_summary,
+            event_trace,
+        );
+        if conversation.title.is_empty() && conversation.history.len() >= 2 {
+            self.spawn_title_generation(conversation_id, agent, created_by, conversation_mutex);
         }
     }
 

--- a/crates/runtime/src/engine/conversation.rs
+++ b/crates/runtime/src/engine/conversation.rs
@@ -29,7 +29,7 @@ impl<C: Config> Runtime<C> {
     ///    conversation.
     /// 2. Otherwise return/create the tmp conversation for this pair —
     ///    in-memory only, no storage I/O, no resume. Topic-bound chats
-    ///    reach storage via `switch_active_topic`.
+    ///    reach storage via `switch_topic`.
     pub async fn get_or_create_conversation(&self, agent: &str, created_by: &str) -> Result<u64> {
         if !self.has_agent(agent).await {
             bail!("agent '{agent}' not registered");
@@ -65,7 +65,7 @@ impl<C: Config> Runtime<C> {
     }
 
     /// Load a specific conversation by session handle.
-    pub async fn load_specific_conversation(&self, handle: SessionHandle) -> Result<u64> {
+    pub async fn load_session(&self, handle: SessionHandle) -> Result<u64> {
         let storage = self.storage();
         let snapshot = storage
             .load_session(&handle)?
@@ -85,9 +85,7 @@ impl<C: Config> Runtime<C> {
         Ok(id)
     }
 
-    pub async fn active_conversation_infos(
-        &self,
-    ) -> Vec<wcore::protocol::message::ActiveConversationInfo> {
+    pub async fn list_active(&self) -> Vec<wcore::protocol::message::ActiveConversationInfo> {
         let conversations = self.conversations.read().await;
         let mut infos = Vec::with_capacity(conversations.len());
         for (_, conv_slot) in conversations.iter() {
@@ -103,7 +101,7 @@ impl<C: Config> Runtime<C> {
         infos
     }
 
-    pub async fn close_conversation(&self, id: u64) -> bool {
+    pub async fn close(&self, id: u64) -> bool {
         self.steering.write().await.remove(&id);
         let removed = self.conversations.write().await.remove(&id);
         if let Some(slot) = &removed {
@@ -175,7 +173,7 @@ impl<C: Config> Runtime<C> {
         self.conversations.read().await.len()
     }
 
-    pub async fn find_conversation_id(&self, agent: &str, sender: &str) -> Option<u64> {
+    pub async fn conversation_id(&self, agent: &str, sender: &str) -> Option<u64> {
         let conversations = self.conversations.read().await;
         for (id, slot) in conversations.iter() {
             if slot.agent == agent && slot.created_by == sender {
@@ -185,7 +183,7 @@ impl<C: Config> Runtime<C> {
         None
     }
 
-    pub async fn compact_conversation(&self, conversation_id: u64) -> Option<String> {
+    pub async fn compact(&self, conversation_id: u64) -> Option<String> {
         let (agent_name, history) = {
             let conversations = self.conversations.read().await;
             let slot = conversations.get(&conversation_id)?;
@@ -204,7 +202,7 @@ impl<C: Config> Runtime<C> {
             .await
     }
 
-    pub async fn transfer_conversations<C2: Config>(&self, dest: &mut Runtime<C2>) {
+    pub async fn transfer_to<C2: Config>(&self, dest: &mut Runtime<C2>) {
         let conversations = self.conversations.read().await;
         let dest_conversations = dest.conversations.get_mut();
         for (id, slot) in conversations.iter() {

--- a/crates/runtime/src/engine/conversation.rs
+++ b/crates/runtime/src/engine/conversation.rs
@@ -16,6 +16,15 @@ use wcore::{
 
 use super::{ConvSlot, Runtime};
 
+/// Outcome of `switch_active_topic`. `resumed = true` means the topic
+/// already existed (in the router or on disk); `false` means it was
+/// freshly created.
+#[derive(Debug, Clone, Copy)]
+pub struct SwitchOutcome {
+    pub conversation_id: u64,
+    pub resumed: bool,
+}
+
 fn archive_base_name(session_slug: &str) -> String {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -33,46 +42,237 @@ impl<C: Config> Runtime<C> {
         }
     }
 
-    /// Get or create a conversation for the given (agent, created_by) identity.
+    /// Get or create a conversation for the given (agent, created_by)
+    /// identity. Routing order:
+    ///
+    /// 1. If `(agent, sender)` has an active topic, return that topic's
+    ///    conversation.
+    /// 2. Otherwise return/create the tmp conversation for this pair —
+    ///    in-memory only, no storage I/O, no resume. Topic-bound chats
+    ///    reach storage via `switch_active_topic`.
     pub async fn get_or_create_conversation(&self, agent: &str, created_by: &str) -> Result<u64> {
         if !self.has_agent(agent).await {
             bail!("agent '{agent}' not registered");
         }
 
-        // 1. Storage lookup outside lock to avoid holding runtime locks over I/O.
-        let storage = self.storage();
-        let loaded = storage
-            .find_latest_session(agent, created_by)
-            .ok()
-            .flatten()
-            .and_then(|handle| {
-                storage
-                    .load_session(&handle)
-                    .ok()
-                    .flatten()
-                    .map(|s| (handle, s))
-            });
+        let key = (agent.to_owned(), created_by.to_owned());
 
-        // 2. Atomic scan + insert under one write lock.
-        let mut conversations = self.conversations.write().await;
-        for (id, slot) in conversations.iter() {
-            if slot.agent == agent && slot.created_by == created_by {
-                return Ok(*id);
+        // Read-first: the common case is a hit on an existing tmp or
+        // active-topic conversation. Avoid allocating a `TopicRouter`
+        // until we actually need to insert one.
+        {
+            let topics = self.topics.read().await;
+            if let Some(router) = topics.get(&key)
+                && let Some(id) = router
+                    .active
+                    .as_ref()
+                    .and_then(|t| router.by_title.get(t).copied())
+                    .or(router.tmp)
+            {
+                return Ok(id);
             }
         }
 
         let id = self.next_conversation_id.fetch_add(1, Ordering::Relaxed);
         let slot = Self::new_slot(id, agent, created_by);
-        if let Some((handle, snapshot)) = loaded {
-            let mut conversation = slot.inner.lock().await;
-            conversation.history =
-                self.resumed_history(snapshot.archive.as_deref(), snapshot.history);
-            conversation.title = snapshot.meta.title;
-            conversation.uptime_secs = snapshot.meta.uptime_secs;
-            conversation.handle = Some(handle);
+        let mut topics = self.topics.write().await;
+        let router = topics.entry(key).or_default();
+        // Re-check under write lock in case another task raced us.
+        if let Some(existing) = router
+            .active
+            .as_ref()
+            .and_then(|t| router.by_title.get(t).copied())
+            .or(router.tmp)
+        {
+            return Ok(existing);
         }
-        conversations.insert(id, slot);
+        router.tmp = Some(id);
+        drop(topics);
+        self.conversations.write().await.insert(id, slot);
         Ok(id)
+    }
+
+    /// Switch the active topic for `(agent, sender)`. Creates a new
+    /// topic conversation if the title doesn't exist yet; resumes the
+    /// existing one otherwise. When creating, writes an
+    /// `EntryKind::Topic` memory entry (unless one already exists for
+    /// the title) so the topic is searchable via `search_topics`.
+    ///
+    /// Returns the target `conversation_id` in the outcome. The caller
+    /// is responsible for telling the user which conversation to route
+    /// the next message to — this call only updates runtime state.
+    pub async fn switch_active_topic(
+        &self,
+        agent: &str,
+        sender: &str,
+        title: &str,
+        description: Option<&str>,
+    ) -> Result<SwitchOutcome> {
+        if !self.has_agent(agent).await {
+            bail!("agent '{agent}' not registered");
+        }
+        if title.is_empty() {
+            bail!("topic title cannot be empty");
+        }
+
+        let key = (agent.to_owned(), sender.to_owned());
+
+        // Reserve the slot under the router lock — any concurrent
+        // caller that races us observes the reservation on the next
+        // lookup and resumes to our conversation instead of creating a
+        // duplicate session.
+        let id = {
+            let mut topics = self.topics.write().await;
+            let router = topics.entry(key.clone()).or_default();
+            if let Some(id) = router.by_title.get(title).copied() {
+                router.active = Some(title.to_owned());
+                return Ok(SwitchOutcome {
+                    conversation_id: id,
+                    resumed: true,
+                });
+            }
+            let id = self.next_conversation_id.fetch_add(1, Ordering::Relaxed);
+            router.by_title.insert(title.to_owned(), id);
+            router.active = Some(title.to_owned());
+            id
+        };
+
+        match self
+            .finalize_topic_switch(agent, sender, title, description, id)
+            .await
+        {
+            Ok(outcome) => Ok(outcome),
+            Err(e) => {
+                self.rollback_topic_reservation(&key, title).await;
+                Err(e)
+            }
+        }
+    }
+
+    /// Cold-path body of `switch_active_topic`. Called after the slot
+    /// has been reserved; any error here triggers a router rollback.
+    async fn finalize_topic_switch(
+        &self,
+        agent: &str,
+        sender: &str,
+        title: &str,
+        description: Option<&str>,
+        id: u64,
+    ) -> Result<SwitchOutcome> {
+        let existing = self.find_topic_session(agent, sender, title);
+        let resumed = existing.is_some();
+
+        if !resumed {
+            let desc = description.ok_or_else(|| {
+                anyhow::anyhow!("description required when creating a new topic '{title}'")
+            })?;
+            self.ensure_topic_entry(title, desc);
+        }
+
+        let slot = Self::new_slot(id, agent, sender);
+        {
+            let mut conversation = slot.inner.lock().await;
+            conversation.topic = Some(title.to_owned());
+            match existing {
+                Some((handle, snapshot)) => {
+                    conversation.history =
+                        self.resumed_history(snapshot.archive.as_deref(), snapshot.history);
+                    conversation.title = snapshot.meta.title;
+                    conversation.uptime_secs = snapshot.meta.uptime_secs;
+                    conversation.handle = Some(handle);
+                }
+                None => {
+                    let storage = self.storage();
+                    let handle = storage.create_session(agent, sender)?;
+                    // Stamp meta so the new session carries its topic
+                    // from the first write — a missing `topic` here
+                    // would make the session invisible to future
+                    // `find_topic_session` scans.
+                    storage.update_session_meta(
+                        &handle,
+                        &wcore::storage::ConversationMeta {
+                            agent: agent.to_owned(),
+                            created_by: sender.to_owned(),
+                            created_at: chrono::Utc::now().to_rfc3339(),
+                            title: String::new(),
+                            uptime_secs: 0,
+                            topic: Some(title.to_owned()),
+                        },
+                    )?;
+                    conversation.handle = Some(handle);
+                }
+            }
+        }
+
+        self.conversations.write().await.insert(id, slot);
+        Ok(SwitchOutcome {
+            conversation_id: id,
+            resumed,
+        })
+    }
+
+    async fn rollback_topic_reservation(&self, key: &(String, String), title: &str) {
+        let mut topics = self.topics.write().await;
+        let Some(router) = topics.get_mut(key) else {
+            return;
+        };
+        router.by_title.remove(title);
+        if router.active.as_deref() == Some(title) {
+            router.active = None;
+        }
+        if router.by_title.is_empty() && router.active.is_none() && router.tmp.is_none() {
+            topics.remove(key);
+        }
+    }
+
+    /// Scan storage for a session matching `(agent, sender, topic)`.
+    /// Blocking I/O; call from outside the runtime locks.
+    fn find_topic_session(
+        &self,
+        agent: &str,
+        sender: &str,
+        title: &str,
+    ) -> Option<(SessionHandle, wcore::storage::SessionSnapshot)> {
+        let storage = self.storage();
+        let summaries = storage.list_sessions().ok()?;
+        let mut match_: Option<(SessionHandle, wcore::storage::ConversationMeta)> = None;
+        for summary in summaries {
+            if summary.meta.agent != agent || summary.meta.created_by != sender {
+                continue;
+            }
+            if summary.meta.topic.as_deref() != Some(title) {
+                continue;
+            }
+            // Later sessions win — `created_at` is an RFC3339 string so
+            // lexicographic comparison is chronological.
+            if match_
+                .as_ref()
+                .is_none_or(|(_, meta)| summary.meta.created_at > meta.created_at)
+            {
+                match_ = Some((summary.handle, summary.meta));
+            }
+        }
+        let (handle, _) = match_?;
+        let snapshot = storage.load_session(&handle).ok().flatten()?;
+        Some((handle, snapshot))
+    }
+
+    /// Write the Topic memory entry if it doesn't already exist.
+    /// Duplicate-name errors are ignored — a prior process may have
+    /// created the same topic.
+    fn ensure_topic_entry(&self, title: &str, description: &str) {
+        let mut mem = self.memory.write();
+        if mem.get(title).is_some() {
+            return;
+        }
+        if let Err(e) = mem.apply(Op::Add {
+            name: title.to_owned(),
+            content: description.to_owned(),
+            aliases: vec![],
+            kind: EntryKind::Topic,
+        }) {
+            tracing::warn!("topic entry write failed: {e}");
+        }
     }
 
     /// Load a specific conversation by session handle.
@@ -116,7 +316,28 @@ impl<C: Config> Runtime<C> {
 
     pub async fn close_conversation(&self, id: u64) -> bool {
         self.steering.write().await.remove(&id);
-        self.conversations.write().await.remove(&id).is_some()
+        let removed = self.conversations.write().await.remove(&id);
+        if let Some(slot) = &removed {
+            let key = (slot.agent.clone(), slot.created_by.clone());
+            let mut topics = self.topics.write().await;
+            if let Some(router) = topics.get_mut(&key) {
+                if router.tmp == Some(id) {
+                    router.tmp = None;
+                }
+                router.by_title.retain(|_, cid| *cid != id);
+                if router
+                    .active
+                    .as_ref()
+                    .is_some_and(|t| !router.by_title.contains_key(t))
+                {
+                    router.active = None;
+                }
+                if router.tmp.is_none() && router.by_title.is_empty() {
+                    topics.remove(&key);
+                }
+            }
+        }
+        removed.is_some()
     }
 
     pub async fn steer(&self, conversation_id: u64, content: String) -> Result<()> {
@@ -241,10 +462,11 @@ impl<C: Config> Runtime<C> {
         }
     }
 
-    /// Ensure the conversation has a session handle, creating one via
-    /// the repo if needed. Called before the first persist.
+    /// Ensure a topic-bound conversation has a session handle, creating
+    /// one via the repo if needed. Tmp chats (no topic) are in-memory
+    /// only — never persisted, never assigned a handle.
     fn ensure_handle(&self, conversation: &mut Conversation, agent: &str, created_by: &str) {
-        if conversation.handle.is_some() {
+        if conversation.handle.is_some() || conversation.topic.is_none() {
             return;
         }
         let storage = self.storage();

--- a/crates/runtime/src/engine/conversation.rs
+++ b/crates/runtime/src/engine/conversation.rs
@@ -1,15 +1,12 @@
 //! Conversation management — lifecycle, persistence, and title generation.
 
-use crate::{Config, Conversation};
+use crate::{Config, Conversation, ConversationHandle};
 use anyhow::{Result, bail};
 use crabllm_core::{ChatCompletionRequest, Message, Role};
 use memory::{EntryKind, Op};
 use std::sync::{Arc, atomic::Ordering};
 use tokio::sync::Mutex;
-use wcore::{
-    model::HistoryEntry,
-    storage::{SessionHandle, Storage},
-};
+use wcore::{model::HistoryEntry, storage::Storage};
 
 use super::{ConvSlot, Runtime, TopicRouter};
 
@@ -50,49 +47,64 @@ impl<C: Config> Runtime<C> {
             return Ok(id);
         }
 
-        let id = self.next_conversation_id.fetch_add(1, Ordering::Relaxed);
+        // Reserve an id under the router write lock; release it before
+        // taking the conversations write lock to keep hold-times short.
+        let id = {
+            let mut topics = self.topics.write().await;
+            let router = topics.entry(key).or_default();
+            if let Some(existing) = router.active_conversation() {
+                return Ok(existing);
+            }
+            let id = self.next_conversation_id.fetch_add(1, Ordering::Relaxed);
+            router.tmp = Some(id);
+            id
+        };
         let slot = Self::new_slot(id, agent, created_by);
-        let mut topics = self.topics.write().await;
-        let router = topics.entry(key).or_default();
-        // Re-check under write lock in case another task raced us.
-        if let Some(existing) = router.active_conversation() {
-            return Ok(existing);
-        }
-        router.tmp = Some(id);
-        drop(topics);
         self.conversations.write().await.insert(id, slot);
         Ok(id)
     }
 
-    /// Load a specific conversation by session handle.
-    pub async fn load_session(&self, handle: SessionHandle) -> Result<u64> {
+    /// Load a specific conversation by persistent handle.
+    pub async fn load(&self, handle: ConversationHandle) -> Result<u64> {
         let storage = self.storage();
         let snapshot = storage
             .load_session(&handle)?
-            .ok_or_else(|| anyhow::anyhow!("session '{}' not found", handle.as_str()))?;
+            .ok_or_else(|| anyhow::anyhow!("conversation '{}' not found", handle.as_str()))?;
         if !self.has_agent(&snapshot.meta.agent).await {
             bail!("agent '{}' not registered", snapshot.meta.agent);
         }
         let id = self.next_conversation_id.fetch_add(1, Ordering::Relaxed);
         let slot = Self::new_slot(id, &snapshot.meta.agent, &snapshot.meta.created_by);
-        let mut conversation = slot.inner.lock().await;
-        conversation.history = self.resumed_history(snapshot.archive.as_deref(), snapshot.history);
-        conversation.title = snapshot.meta.title;
-        conversation.uptime_secs = snapshot.meta.uptime_secs;
-        conversation.handle = Some(handle);
-        drop(conversation);
+        {
+            let mut conversation = slot.inner.lock().await;
+            conversation.history =
+                self.resumed_history(snapshot.archive.as_deref(), snapshot.history);
+            conversation.title = snapshot.meta.title;
+            conversation.uptime_secs = snapshot.meta.uptime_secs;
+            conversation.handle = Some(handle);
+        }
         self.conversations.write().await.insert(id, slot);
         Ok(id)
     }
 
     pub async fn list_active(&self) -> Vec<wcore::protocol::message::ActiveConversationInfo> {
-        let conversations = self.conversations.read().await;
-        let mut infos = Vec::with_capacity(conversations.len());
-        for (_, conv_slot) in conversations.iter() {
-            let c = conv_slot.inner.lock().await;
+        // Snapshot the slot metadata and mutex handles first so the
+        // outer read guard isn't held across per-conversation locks —
+        // otherwise a slow conversation would block readers of the
+        // whole map.
+        let slots: Vec<_> = {
+            let conversations = self.conversations.read().await;
+            conversations
+                .values()
+                .map(|s| (s.agent.clone(), s.created_by.clone(), s.inner.clone()))
+                .collect()
+        };
+        let mut infos = Vec::with_capacity(slots.len());
+        for (agent, sender, mutex) in slots {
+            let c = mutex.lock().await;
             infos.push(wcore::protocol::message::ActiveConversationInfo {
-                agent: conv_slot.agent.clone(),
-                sender: conv_slot.created_by.clone(),
+                agent,
+                sender,
                 message_count: c.history.len() as u64,
                 alive_secs: c.uptime_secs,
                 title: c.title.clone(),
@@ -184,17 +196,20 @@ impl<C: Config> Runtime<C> {
     }
 
     pub async fn compact(&self, conversation_id: u64) -> Option<String> {
-        let (agent_name, history) = {
+        // Release the conversations read lock before the per-conversation
+        // mutex await — otherwise readers queue behind a potentially
+        // contended inner lock.
+        let (agent_name, conversation_mutex) = {
             let conversations = self.conversations.read().await;
             let slot = conversations.get(&conversation_id)?;
-            let agent_name = slot.agent.clone();
-            let conversation_mutex = slot.inner.clone();
-            drop(conversations);
+            (slot.agent.clone(), slot.inner.clone())
+        };
+        let history = {
             let conversation = conversation_mutex.lock().await;
             if conversation.history.is_empty() {
                 return None;
             }
-            (agent_name, conversation.history.clone())
+            conversation.history.clone()
         };
         self.resolve_agent(&agent_name)
             .await?

--- a/crates/runtime/src/engine/conversation.rs
+++ b/crates/runtime/src/engine/conversation.rs
@@ -4,10 +4,7 @@ use crate::{Config, Conversation};
 use anyhow::{Result, bail};
 use crabllm_core::{ChatCompletionRequest, Message, Role};
 use memory::{EntryKind, Op};
-use std::{
-    sync::{Arc, atomic::Ordering},
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::sync::{Arc, atomic::Ordering};
 use tokio::sync::Mutex;
 use wcore::{
     model::HistoryEntry,
@@ -23,14 +20,6 @@ use super::{ConvSlot, Runtime};
 pub struct SwitchOutcome {
     pub conversation_id: u64,
     pub resumed: bool,
-}
-
-fn archive_base_name(session_slug: &str) -> String {
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    format!("archive-{session_slug}-{nanos}")
 }
 
 impl<C: Config> Runtime<C> {
@@ -442,12 +431,34 @@ impl<C: Config> Runtime<C> {
         out
     }
 
-    /// Write a compaction summary to memory as an `Archive` entry and
-    /// return the generated entry name. `None` on failure — the caller
-    /// must skip the compact marker so a resume can't dangle.
-    fn write_archive(&self, session_slug: &str, summary: String) -> Option<String> {
-        let name = archive_base_name(session_slug);
+    /// Write a compaction summary to memory as an `Archive` entry,
+    /// named `{topic-slug}-{n}` where `n` is the next free sequence
+    /// number for this topic. Older archives stay searchable via
+    /// `recall`, so a long-running topic's phases don't get
+    /// overwritten. Returns the generated name, or `None` on failure
+    /// — the caller must skip the compact marker so a resume can't
+    /// dangle.
+    fn write_archive(&self, topic: &str, summary: String) -> Option<String> {
+        let slug = wcore::sender_slug(topic);
+        let prefix = format!("{slug}-");
         let mut mem = self.memory.write();
+        // Scan and insert under the same write lock — two concurrent
+        // compactions can't both pick `seq` and collide.
+        let next_seq = mem
+            .list()
+            .filter(|e| e.kind == EntryKind::Archive && e.name.starts_with(&prefix))
+            .filter_map(|e| {
+                let suffix = &e.name[prefix.len()..];
+                let n: u32 = suffix.parse().ok()?;
+                // Reject non-canonical forms ("02", "+1", etc.) so a
+                // future `{slug}-2` can't collide with a historic
+                // `{slug}-02`.
+                (n.to_string() == suffix).then_some(n)
+            })
+            .max()
+            .unwrap_or(0)
+            + 1;
+        let name = format!("{slug}-{next_seq}");
         match mem.apply(Op::Add {
             name: name.clone(),
             content: summary,
@@ -494,9 +505,15 @@ impl<C: Config> Runtime<C> {
         let storage = self.storage();
 
         if let Some(summary) = compact_summary {
+            // A persisted conversation is always topic-bound —
+            // `ensure_handle` refuses to create a handle for tmp chats.
+            let topic = conversation
+                .topic
+                .clone()
+                .expect("persisted conversation without a topic");
             // Archive first — if this fails, don't write a dangling
             // marker that points at nothing.
-            if let Some(archive_name) = self.write_archive(handle.as_str(), summary) {
+            if let Some(archive_name) = self.write_archive(&topic, summary) {
                 let _ = storage.append_session_compact(handle, &archive_name);
                 if conversation.history.len() > 1 {
                     let tail: Vec<_> = conversation.history[1..]

--- a/crates/runtime/src/engine/conversation.rs
+++ b/crates/runtime/src/engine/conversation.rs
@@ -13,17 +13,8 @@ use wcore::{
 
 use super::{ConvSlot, Runtime, TopicRouter};
 
-/// Outcome of `switch_active_topic`. `resumed = true` means the topic
-/// already existed (in the router or on disk); `false` means it was
-/// freshly created.
-#[derive(Debug, Clone, Copy)]
-pub struct SwitchOutcome {
-    pub conversation_id: u64,
-    pub resumed: bool,
-}
-
 impl<C: Config> Runtime<C> {
-    fn new_slot(id: u64, agent: &str, created_by: &str) -> ConvSlot {
+    pub(super) fn new_slot(id: u64, agent: &str, created_by: &str) -> ConvSlot {
         ConvSlot {
             agent: agent.to_owned(),
             created_by: created_by.to_owned(),
@@ -71,180 +62,6 @@ impl<C: Config> Runtime<C> {
         drop(topics);
         self.conversations.write().await.insert(id, slot);
         Ok(id)
-    }
-
-    /// Switch the active topic for `(agent, sender)`. Creates a new
-    /// topic conversation if the title doesn't exist yet; resumes the
-    /// existing one otherwise. When creating, writes an
-    /// `EntryKind::Topic` memory entry (unless one already exists for
-    /// the title) so the topic is searchable via `search_topics`.
-    ///
-    /// Returns the target `conversation_id` in the outcome. The caller
-    /// is responsible for telling the user which conversation to route
-    /// the next message to — this call only updates runtime state.
-    pub async fn switch_active_topic(
-        &self,
-        agent: &str,
-        sender: &str,
-        title: &str,
-        description: Option<&str>,
-    ) -> Result<SwitchOutcome> {
-        if !self.has_agent(agent).await {
-            bail!("agent '{agent}' not registered");
-        }
-        if title.is_empty() {
-            bail!("topic title cannot be empty");
-        }
-
-        let key = (agent.to_owned(), sender.to_owned());
-
-        // Reserve the slot under the router lock — any concurrent
-        // caller that races us observes the reservation on the next
-        // lookup and resumes to our conversation instead of creating a
-        // duplicate session.
-        let id = {
-            let mut topics = self.topics.write().await;
-            let router = topics.entry(key.clone()).or_default();
-            if let Some(id) = router.by_title.get(title).copied() {
-                router.active = Some(title.to_owned());
-                return Ok(SwitchOutcome {
-                    conversation_id: id,
-                    resumed: true,
-                });
-            }
-            let id = self.next_conversation_id.fetch_add(1, Ordering::Relaxed);
-            router.by_title.insert(title.to_owned(), id);
-            router.active = Some(title.to_owned());
-            id
-        };
-
-        match self
-            .finalize_topic_switch(agent, sender, title, description, id)
-            .await
-        {
-            Ok(outcome) => Ok(outcome),
-            Err(e) => {
-                self.rollback_topic_reservation(&key, title).await;
-                Err(e)
-            }
-        }
-    }
-
-    /// Cold-path body of `switch_active_topic`. Called after the slot
-    /// has been reserved; any error here triggers a router rollback.
-    async fn finalize_topic_switch(
-        &self,
-        agent: &str,
-        sender: &str,
-        title: &str,
-        description: Option<&str>,
-        id: u64,
-    ) -> Result<SwitchOutcome> {
-        let existing = self.find_topic_session(agent, sender, title);
-        let resumed = existing.is_some();
-
-        if !resumed {
-            let desc = description.ok_or_else(|| {
-                anyhow::anyhow!("description required when creating a new topic '{title}'")
-            })?;
-            self.ensure_topic_entry(title, desc);
-        }
-
-        let slot = Self::new_slot(id, agent, sender);
-        {
-            let mut conversation = slot.inner.lock().await;
-            conversation.topic = Some(title.to_owned());
-            match existing {
-                Some((handle, snapshot)) => {
-                    conversation.history =
-                        self.resumed_history(snapshot.archive.as_deref(), snapshot.history);
-                    conversation.title = snapshot.meta.title;
-                    conversation.uptime_secs = snapshot.meta.uptime_secs;
-                    conversation.handle = Some(handle);
-                }
-                None => {
-                    let storage = self.storage();
-                    let handle = storage.create_session(agent, sender)?;
-                    // Stamp meta so the new session carries its topic
-                    // from the first write — a missing `topic` here
-                    // would make the session invisible to future
-                    // `find_topic_session` scans. `conversation.meta`
-                    // already reflects the topic we set above.
-                    storage.update_session_meta(&handle, &conversation.meta(agent, sender))?;
-                    conversation.handle = Some(handle);
-                }
-            }
-        }
-
-        self.conversations.write().await.insert(id, slot);
-        Ok(SwitchOutcome {
-            conversation_id: id,
-            resumed,
-        })
-    }
-
-    async fn rollback_topic_reservation(&self, key: &(String, String), title: &str) {
-        let mut topics = self.topics.write().await;
-        let Some(router) = topics.get_mut(key) else {
-            return;
-        };
-        router.by_title.remove(title);
-        if router.active.as_deref() == Some(title) {
-            router.active = None;
-        }
-        if router.by_title.is_empty() && router.active.is_none() && router.tmp.is_none() {
-            topics.remove(key);
-        }
-    }
-
-    /// Scan storage for a session matching `(agent, sender, topic)`.
-    /// Blocking I/O; call from outside the runtime locks.
-    fn find_topic_session(
-        &self,
-        agent: &str,
-        sender: &str,
-        title: &str,
-    ) -> Option<(SessionHandle, wcore::storage::SessionSnapshot)> {
-        let storage = self.storage();
-        let summaries = storage.list_sessions().ok()?;
-        let mut match_: Option<(SessionHandle, wcore::storage::ConversationMeta)> = None;
-        for summary in summaries {
-            if summary.meta.agent != agent || summary.meta.created_by != sender {
-                continue;
-            }
-            if summary.meta.topic.as_deref() != Some(title) {
-                continue;
-            }
-            // Later sessions win — `created_at` is an RFC3339 string so
-            // lexicographic comparison is chronological.
-            if match_
-                .as_ref()
-                .is_none_or(|(_, meta)| summary.meta.created_at > meta.created_at)
-            {
-                match_ = Some((summary.handle, summary.meta));
-            }
-        }
-        let (handle, _) = match_?;
-        let snapshot = storage.load_session(&handle).ok().flatten()?;
-        Some((handle, snapshot))
-    }
-
-    /// Write the Topic memory entry if it doesn't already exist.
-    /// Duplicate-name errors are ignored — a prior process may have
-    /// created the same topic.
-    fn ensure_topic_entry(&self, title: &str, description: &str) {
-        let mut mem = self.memory.write();
-        if mem.get(title).is_some() {
-            return;
-        }
-        if let Err(e) = mem.apply(Op::Add {
-            name: title.to_owned(),
-            content: description.to_owned(),
-            aliases: vec![],
-            kind: EntryKind::Topic,
-        }) {
-            tracing::warn!("topic entry write failed: {e}");
-        }
     }
 
     /// Load a specific conversation by session handle.
@@ -402,7 +219,7 @@ impl<C: Config> Runtime<C> {
     /// (memory wiped, different machine, etc.) injects a visible placeholder
     /// so the model can acknowledge the gap instead of silently truncating
     /// the user's context.
-    fn resumed_history(
+    pub(super) fn resumed_history(
         &self,
         archive: Option<&str>,
         mut history: Vec<HistoryEntry>,
@@ -482,6 +299,7 @@ impl<C: Config> Runtime<C> {
     /// `guest_stream_to`: update uptime, persist, and kick off title
     /// generation if the conversation has a titleable exchange and no
     /// title yet.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn finalize_run(
         &self,
         conversation_id: u64,

--- a/crates/runtime/src/engine/conversation.rs
+++ b/crates/runtime/src/engine/conversation.rs
@@ -1,5 +1,6 @@
 //! Conversation management — lifecycle, persistence, and title generation.
 
+use super::{ConvSlot, Runtime, TopicRouter};
 use crate::{Config, Conversation, ConversationHandle};
 use anyhow::{Result, bail};
 use crabllm_core::{ChatCompletionRequest, Message, Role};
@@ -7,8 +8,6 @@ use memory::{EntryKind, Op};
 use std::sync::{Arc, atomic::Ordering};
 use tokio::sync::Mutex;
 use wcore::{model::HistoryEntry, storage::Storage};
-
-use super::{ConvSlot, Runtime, TopicRouter};
 
 impl<C: Config> Runtime<C> {
     pub(super) fn new_slot(id: u64, agent: &str, created_by: &str) -> ConvSlot {

--- a/crates/runtime/src/engine/execution.rs
+++ b/crates/runtime/src/engine/execution.rs
@@ -9,7 +9,7 @@ use futures_util::StreamExt;
 use tokio::sync::{mpsc, watch};
 use wcore::{AgentEvent, AgentResponse, AgentStopReason, model::HistoryEntry};
 
-use super::{ConvSlot, Runtime};
+use super::Runtime;
 
 impl<C: Config> Runtime<C> {
     fn prepare_history(
@@ -74,14 +74,10 @@ impl<C: Config> Runtime<C> {
         sender: &str,
         tool_choice: Option<ToolChoice>,
     ) -> Result<AgentResponse> {
-        let conversation_mutex = self
-            .conversations
-            .read()
+        let (agent_name, created_by, conversation_mutex) = self
+            .acquire_slot(conversation_id)
             .await
-            .get(&conversation_id)
-            .map(ConvSlot::parts)
             .ok_or_else(|| anyhow::anyhow!("conversation {conversation_id} not found"))?;
-        let (agent_name, created_by, conversation_mutex) = conversation_mutex;
 
         let mut conversation = conversation_mutex.lock().await;
         let pre_run_len = conversation.history.len();
@@ -96,7 +92,6 @@ impl<C: Config> Runtime<C> {
         let response = agent
             .run(&mut conversation.history, tx, None, tool_choice)
             .await;
-        conversation.uptime_secs += run_start.elapsed().as_secs();
 
         let mut compact_summary: Option<String> = None;
         while let Ok(event) = rx.try_recv() {
@@ -110,23 +105,17 @@ impl<C: Config> Runtime<C> {
                 .on_agent_event(&agent_name, conversation_id, &event);
         }
 
-        self.persist_messages(
+        self.finalize_run(
+            conversation_id,
             &mut conversation,
+            conversation_mutex.clone(),
             &agent_name,
             &created_by,
+            run_start,
             pre_run_len,
             compact_summary,
             &[],
         );
-
-        if conversation.title.is_empty() && conversation.history.len() >= 2 {
-            self.spawn_title_generation(
-                conversation_id,
-                &agent_name,
-                &created_by,
-                conversation_mutex.clone(),
-            );
-        }
         Ok(response)
     }
 
@@ -140,19 +129,14 @@ impl<C: Config> Runtime<C> {
         let content = content.to_owned();
         let sender = sender.to_owned();
         stream! {
-            let Some(conversation_mutex) = self
-                .conversations
-                .read()
-                .await
-                .get(&conversation_id)
-                .map(ConvSlot::parts)
+            let Some((agent_name, created_by, conversation_mutex)) =
+                self.acquire_slot(conversation_id).await
             else {
                 yield AgentEvent::Done(AgentResponse::error(
                     format!("conversation {conversation_id} not found"),
                 ));
                 return;
             };
-            let (agent_name, created_by, conversation_mutex) = conversation_mutex;
 
             let mut conversation = conversation_mutex.lock().await;
             let pre_run_len = conversation.history.len();
@@ -189,24 +173,17 @@ impl<C: Config> Runtime<C> {
                 }
             }
             self.steering.write().await.remove(&conversation_id);
-            conversation.uptime_secs += run_start.elapsed().as_secs();
-            self.persist_messages(
+            self.finalize_run(
+                conversation_id,
                 &mut conversation,
+                conversation_mutex.clone(),
                 &agent_name,
                 &created_by,
+                run_start,
                 pre_run_len,
                 compact_summary,
                 &event_trace,
             );
-
-            if conversation.title.is_empty() && conversation.history.len() >= 2 {
-                self.spawn_title_generation(
-                    conversation_id,
-                    &agent_name,
-                    &created_by,
-                    conversation_mutex.clone(),
-                );
-            }
             if let Some(event) = done_event {
                 yield event;
             }
@@ -231,19 +208,14 @@ impl<C: Config> Runtime<C> {
                 return;
             };
 
-            let Some(conversation_mutex) = self
-                .conversations
-                .read()
-                .await
-                .get(&conversation_id)
-                .map(ConvSlot::parts)
+            let Some((agent_name, created_by, conversation_mutex)) =
+                self.acquire_slot(conversation_id).await
             else {
                 yield AgentEvent::Done(AgentResponse::error(
                     format!("conversation {conversation_id} not found"),
                 ));
                 return;
             };
-            let (agent_name, created_by, conversation_mutex) = conversation_mutex;
 
             let mut conversation = conversation_mutex.lock().await;
             let pre_run_len = conversation.history.len();
@@ -343,24 +315,17 @@ impl<C: Config> Runtime<C> {
             response_entry.agent = guest.clone();
             conversation.history.push(response_entry);
 
-            conversation.uptime_secs += run_start.elapsed().as_secs();
-            self.persist_messages(
+            self.finalize_run(
+                conversation_id,
                 &mut conversation,
+                conversation_mutex.clone(),
                 &agent_name,
                 &created_by,
+                run_start,
                 pre_run_len,
                 None,
                 &[],
             );
-
-            if conversation.title.is_empty() && conversation.history.len() >= 2 {
-                self.spawn_title_generation(
-                    conversation_id,
-                    &agent_name,
-                    &created_by,
-                    conversation_mutex.clone(),
-                );
-            }
 
             yield AgentEvent::Done(AgentResponse {
                 final_response: Some(response_text),

--- a/crates/runtime/src/engine/execution.rs
+++ b/crates/runtime/src/engine/execution.rs
@@ -1,5 +1,6 @@
 //! Execution — message sending and streaming through agents.
 
+use super::Runtime;
 use crate::{Config, Conversation, Env, Hook};
 use anyhow::Result;
 use async_stream::stream;
@@ -8,8 +9,6 @@ use futures_core::Stream;
 use futures_util::StreamExt;
 use tokio::sync::{mpsc, watch};
 use wcore::{AgentEvent, AgentResponse, AgentStopReason, model::HistoryEntry};
-
-use super::Runtime;
 
 impl<C: Config> Runtime<C> {
     fn prepare_history(

--- a/crates/runtime/src/engine/mod.rs
+++ b/crates/runtime/src/engine/mod.rs
@@ -10,10 +10,12 @@ mod agents;
 mod conversation;
 mod execution;
 
+pub use conversation::SwitchOutcome;
+
 use crate::{Config, Conversation};
 use memory::Memory;
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashMap},
     sync::{Arc, atomic::AtomicU64},
 };
 use tokio::sync::{Mutex, RwLock, watch};
@@ -41,6 +43,16 @@ impl ConvSlot {
     }
 }
 
+/// Per-(agent, sender) topic routing. `active = None` means the caller
+/// is on a tmp chat (no topic). Tmp chats have their own `ConvSlot` but
+/// are not tracked here.
+#[derive(Default)]
+pub(super) struct TopicRouter {
+    pub(super) by_title: HashMap<String, u64>,
+    pub(super) active: Option<String>,
+    pub(super) tmp: Option<u64>,
+}
+
 /// The crabtalk runtime.
 pub struct Runtime<C: Config> {
     pub model: Model<C::Provider>,
@@ -50,6 +62,7 @@ pub struct Runtime<C: Config> {
     agents: parking_lot::RwLock<BTreeMap<String, Agent<C::Provider>>>,
     ephemeral_agents: RwLock<BTreeMap<String, Agent<C::Provider>>>,
     conversations: RwLock<BTreeMap<u64, ConvSlot>>,
+    pub(super) topics: RwLock<BTreeMap<(String, String), TopicRouter>>,
     next_conversation_id: AtomicU64,
     pub tools: ToolRegistry,
     steering: RwLock<BTreeMap<u64, watch::Sender<Option<String>>>>,
@@ -72,6 +85,7 @@ impl<C: Config> Runtime<C> {
             agents: parking_lot::RwLock::new(BTreeMap::new()),
             ephemeral_agents: RwLock::new(BTreeMap::new()),
             conversations: RwLock::new(BTreeMap::new()),
+            topics: RwLock::new(BTreeMap::new()),
             next_conversation_id: AtomicU64::new(1),
             tools,
             steering: RwLock::new(BTreeMap::new()),

--- a/crates/runtime/src/engine/mod.rs
+++ b/crates/runtime/src/engine/mod.rs
@@ -53,6 +53,18 @@ pub(super) struct TopicRouter {
     pub(super) tmp: Option<u64>,
 }
 
+impl TopicRouter {
+    /// Resolve the conversation this router currently routes to:
+    /// the active topic's conversation if one is set, otherwise the
+    /// tmp conversation if one exists.
+    pub(super) fn active_conversation(&self) -> Option<u64> {
+        self.active
+            .as_ref()
+            .and_then(|t| self.by_title.get(t).copied())
+            .or(self.tmp)
+    }
+}
+
 /// The crabtalk runtime.
 pub struct Runtime<C: Config> {
     pub model: Model<C::Provider>,

--- a/crates/runtime/src/engine/mod.rs
+++ b/crates/runtime/src/engine/mod.rs
@@ -9,13 +9,15 @@
 mod agents;
 mod conversation;
 mod execution;
+mod topic;
 
-pub use conversation::SwitchOutcome;
+pub use topic::SwitchOutcome;
+pub(super) use topic::TopicRouter;
 
 use crate::{Config, Conversation};
 use memory::Memory;
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::BTreeMap,
     sync::{Arc, atomic::AtomicU64},
 };
 use tokio::sync::{Mutex, RwLock, watch};
@@ -40,28 +42,6 @@ impl ConvSlot {
             self.created_by.clone(),
             self.inner.clone(),
         )
-    }
-}
-
-/// Per-(agent, sender) topic routing. `active = None` means the caller
-/// is on a tmp chat (no topic). Tmp chats have their own `ConvSlot` but
-/// are not tracked here.
-#[derive(Default)]
-pub(super) struct TopicRouter {
-    pub(super) by_title: HashMap<String, u64>,
-    pub(super) active: Option<String>,
-    pub(super) tmp: Option<u64>,
-}
-
-impl TopicRouter {
-    /// Resolve the conversation this router currently routes to:
-    /// the active topic's conversation if one is set, otherwise the
-    /// tmp conversation if one exists.
-    pub(super) fn active_conversation(&self) -> Option<u64> {
-        self.active
-            .as_ref()
-            .and_then(|t| self.by_title.get(t).copied())
-            .or(self.tmp)
     }
 }
 

--- a/crates/runtime/src/engine/mod.rs
+++ b/crates/runtime/src/engine/mod.rs
@@ -6,14 +6,6 @@
 //! (`send_to`, `stream_to`) take a conversation ID, lock the conversation,
 //! clone the agent, and run with the conversation's history.
 
-mod agents;
-mod conversation;
-mod execution;
-mod topic;
-
-pub use topic::SwitchOutcome;
-pub(super) use topic::TopicRouter;
-
 use crate::{Config, Conversation};
 use memory::Memory;
 use std::{
@@ -21,7 +13,14 @@ use std::{
     sync::{Arc, atomic::AtomicU64},
 };
 use tokio::sync::{Mutex, RwLock, watch};
+pub use topic::SwitchOutcome;
+pub(super) use topic::TopicRouter;
 use wcore::{Agent, ToolRegistry, model::Model};
+
+mod agents;
+mod conversation;
+mod execution;
+mod topic;
 
 /// Shared handle to the standalone memory store. Used by compaction to
 /// write Archive entries and by session resume to pull their content

--- a/crates/runtime/src/engine/topic.rs
+++ b/crates/runtime/src/engine/topic.rs
@@ -35,7 +35,7 @@ impl TopicRouter {
     }
 }
 
-/// Outcome of `switch_active_topic`. `resumed = true` means the topic
+/// Outcome of `switch_topic`. `resumed = true` means the topic
 /// already existed (in the router or on disk); `false` means it was
 /// freshly created.
 #[derive(Debug, Clone, Copy)]
@@ -54,7 +54,7 @@ impl<C: Config> Runtime<C> {
     /// Returns the target `conversation_id` in the outcome. The caller
     /// is responsible for telling the user which conversation to route
     /// the next message to — this call only updates runtime state.
-    pub async fn switch_active_topic(
+    pub async fn switch_topic(
         &self,
         agent: &str,
         sender: &str,
@@ -91,20 +91,20 @@ impl<C: Config> Runtime<C> {
         };
 
         match self
-            .finalize_topic_switch(agent, sender, title, description, id)
+            .finalize_switch(agent, sender, title, description, id)
             .await
         {
             Ok(outcome) => Ok(outcome),
             Err(e) => {
-                self.rollback_topic_reservation(&key, title).await;
+                self.rollback_reservation(&key, title).await;
                 Err(e)
             }
         }
     }
 
-    /// Cold-path body of `switch_active_topic`. Called after the slot
+    /// Cold-path body of `switch_topic`. Called after the slot
     /// has been reserved; any error here triggers a router rollback.
-    async fn finalize_topic_switch(
+    async fn finalize_switch(
         &self,
         agent: &str,
         sender: &str,
@@ -112,14 +112,14 @@ impl<C: Config> Runtime<C> {
         description: Option<&str>,
         id: u64,
     ) -> Result<SwitchOutcome> {
-        let existing = self.find_topic_session(agent, sender, title);
+        let existing = self.find_session(agent, sender, title);
         let resumed = existing.is_some();
 
         if !resumed {
             let desc = description.ok_or_else(|| {
                 anyhow::anyhow!("description required when creating a new topic '{title}'")
             })?;
-            self.ensure_topic_entry(title, desc);
+            self.ensure_entry(title, desc);
         }
 
         let slot = Self::new_slot(id, agent, sender);
@@ -140,7 +140,7 @@ impl<C: Config> Runtime<C> {
                     // Stamp meta so the new session carries its topic
                     // from the first write — a missing `topic` here
                     // would make the session invisible to future
-                    // `find_topic_session` scans. `conversation.meta`
+                    // `find_session` scans. `conversation.meta`
                     // already reflects the topic we set above.
                     storage.update_session_meta(&handle, &conversation.meta(agent, sender))?;
                     conversation.handle = Some(handle);
@@ -155,7 +155,7 @@ impl<C: Config> Runtime<C> {
         })
     }
 
-    async fn rollback_topic_reservation(&self, key: &(String, String), title: &str) {
+    async fn rollback_reservation(&self, key: &(String, String), title: &str) {
         let mut topics = self.topics.write().await;
         let Some(router) = topics.get_mut(key) else {
             return;
@@ -171,7 +171,7 @@ impl<C: Config> Runtime<C> {
 
     /// Scan storage for a session matching `(agent, sender, topic)`.
     /// Blocking I/O; call from outside the runtime locks.
-    fn find_topic_session(
+    fn find_session(
         &self,
         agent: &str,
         sender: &str,
@@ -204,7 +204,7 @@ impl<C: Config> Runtime<C> {
     /// Write the Topic memory entry if it doesn't already exist.
     /// Duplicate-name errors are ignored — a prior process may have
     /// created the same topic.
-    fn ensure_topic_entry(&self, title: &str, description: &str) {
+    fn ensure_entry(&self, title: &str, description: &str) {
         let mut mem = self.memory.write();
         if mem.get(title).is_some() {
             return;

--- a/crates/runtime/src/engine/topic.rs
+++ b/crates/runtime/src/engine/topic.rs
@@ -4,11 +4,11 @@
 //! title, plus an active-topic pointer. Untopicked chats are tmp and
 //! live only in [`TopicRouter::tmp`]; they never reach storage.
 
-use crate::Config;
+use crate::{Config, ConversationHandle};
 use anyhow::{Result, bail};
 use memory::{EntryKind, Op};
 use std::{collections::HashMap, sync::atomic::Ordering};
-use wcore::storage::{SessionHandle, Storage};
+use wcore::storage::Storage;
 
 use super::Runtime;
 
@@ -176,10 +176,10 @@ impl<C: Config> Runtime<C> {
         agent: &str,
         sender: &str,
         title: &str,
-    ) -> Option<(SessionHandle, wcore::storage::SessionSnapshot)> {
+    ) -> Option<(ConversationHandle, wcore::storage::SessionSnapshot)> {
         let storage = self.storage();
         let summaries = storage.list_sessions().ok()?;
-        let mut match_: Option<(SessionHandle, wcore::storage::ConversationMeta)> = None;
+        let mut best: Option<(ConversationHandle, wcore::storage::ConversationMeta)> = None;
         for summary in summaries {
             if summary.meta.agent != agent || summary.meta.created_by != sender {
                 continue;
@@ -189,14 +189,14 @@ impl<C: Config> Runtime<C> {
             }
             // Later sessions win — `created_at` is an RFC3339 string so
             // lexicographic comparison is chronological.
-            if match_
+            if best
                 .as_ref()
                 .is_none_or(|(_, meta)| summary.meta.created_at > meta.created_at)
             {
-                match_ = Some((summary.handle, summary.meta));
+                best = Some((summary.handle, summary.meta));
             }
         }
-        let (handle, _) = match_?;
+        let (handle, _) = best?;
         let snapshot = storage.load_session(&handle).ok().flatten()?;
         Some((handle, snapshot))
     }

--- a/crates/runtime/src/engine/topic.rs
+++ b/crates/runtime/src/engine/topic.rs
@@ -1,0 +1,221 @@
+//! Topics — per-(agent, sender) conversation partitioning. See
+//! [RFC 0171](https://github.com/crabtalk/crabtalk/issues/171). One
+//! `(agent, sender)` pair maps to N conversations keyed by topic
+//! title, plus an active-topic pointer. Untopicked chats are tmp and
+//! live only in [`TopicRouter::tmp`]; they never reach storage.
+
+use crate::Config;
+use anyhow::{Result, bail};
+use memory::{EntryKind, Op};
+use std::{collections::HashMap, sync::atomic::Ordering};
+use wcore::storage::{SessionHandle, Storage};
+
+use super::Runtime;
+
+/// Per-(agent, sender) topic routing. `active = None` means the caller
+/// is on a tmp chat (no topic). Tmp chats have their own `ConvSlot` but
+/// their id is tracked here so `get_or_create_conversation` can find
+/// them without scanning.
+#[derive(Default)]
+pub struct TopicRouter {
+    pub(super) by_title: HashMap<String, u64>,
+    pub(super) active: Option<String>,
+    pub(super) tmp: Option<u64>,
+}
+
+impl TopicRouter {
+    /// Resolve the conversation this router currently routes to:
+    /// the active topic's conversation if one is set, otherwise the
+    /// tmp conversation if one exists.
+    pub(super) fn active_conversation(&self) -> Option<u64> {
+        self.active
+            .as_ref()
+            .and_then(|t| self.by_title.get(t).copied())
+            .or(self.tmp)
+    }
+}
+
+/// Outcome of `switch_active_topic`. `resumed = true` means the topic
+/// already existed (in the router or on disk); `false` means it was
+/// freshly created.
+#[derive(Debug, Clone, Copy)]
+pub struct SwitchOutcome {
+    pub conversation_id: u64,
+    pub resumed: bool,
+}
+
+impl<C: Config> Runtime<C> {
+    /// Switch the active topic for `(agent, sender)`. Creates a new
+    /// topic conversation if the title doesn't exist yet; resumes the
+    /// existing one otherwise. When creating, writes an
+    /// `EntryKind::Topic` memory entry (unless one already exists for
+    /// the title) so the topic is searchable via `search_topics`.
+    ///
+    /// Returns the target `conversation_id` in the outcome. The caller
+    /// is responsible for telling the user which conversation to route
+    /// the next message to — this call only updates runtime state.
+    pub async fn switch_active_topic(
+        &self,
+        agent: &str,
+        sender: &str,
+        title: &str,
+        description: Option<&str>,
+    ) -> Result<SwitchOutcome> {
+        if !self.has_agent(agent).await {
+            bail!("agent '{agent}' not registered");
+        }
+        if title.is_empty() {
+            bail!("topic title cannot be empty");
+        }
+
+        let key = (agent.to_owned(), sender.to_owned());
+
+        // Reserve the slot under the router lock — any concurrent
+        // caller that races us observes the reservation on the next
+        // lookup and resumes to our conversation instead of creating a
+        // duplicate session.
+        let id = {
+            let mut topics = self.topics.write().await;
+            let router = topics.entry(key.clone()).or_default();
+            if let Some(id) = router.by_title.get(title).copied() {
+                router.active = Some(title.to_owned());
+                return Ok(SwitchOutcome {
+                    conversation_id: id,
+                    resumed: true,
+                });
+            }
+            let id = self.next_conversation_id.fetch_add(1, Ordering::Relaxed);
+            router.by_title.insert(title.to_owned(), id);
+            router.active = Some(title.to_owned());
+            id
+        };
+
+        match self
+            .finalize_topic_switch(agent, sender, title, description, id)
+            .await
+        {
+            Ok(outcome) => Ok(outcome),
+            Err(e) => {
+                self.rollback_topic_reservation(&key, title).await;
+                Err(e)
+            }
+        }
+    }
+
+    /// Cold-path body of `switch_active_topic`. Called after the slot
+    /// has been reserved; any error here triggers a router rollback.
+    async fn finalize_topic_switch(
+        &self,
+        agent: &str,
+        sender: &str,
+        title: &str,
+        description: Option<&str>,
+        id: u64,
+    ) -> Result<SwitchOutcome> {
+        let existing = self.find_topic_session(agent, sender, title);
+        let resumed = existing.is_some();
+
+        if !resumed {
+            let desc = description.ok_or_else(|| {
+                anyhow::anyhow!("description required when creating a new topic '{title}'")
+            })?;
+            self.ensure_topic_entry(title, desc);
+        }
+
+        let slot = Self::new_slot(id, agent, sender);
+        {
+            let mut conversation = slot.inner.lock().await;
+            conversation.topic = Some(title.to_owned());
+            match existing {
+                Some((handle, snapshot)) => {
+                    conversation.history =
+                        self.resumed_history(snapshot.archive.as_deref(), snapshot.history);
+                    conversation.title = snapshot.meta.title;
+                    conversation.uptime_secs = snapshot.meta.uptime_secs;
+                    conversation.handle = Some(handle);
+                }
+                None => {
+                    let storage = self.storage();
+                    let handle = storage.create_session(agent, sender)?;
+                    // Stamp meta so the new session carries its topic
+                    // from the first write — a missing `topic` here
+                    // would make the session invisible to future
+                    // `find_topic_session` scans. `conversation.meta`
+                    // already reflects the topic we set above.
+                    storage.update_session_meta(&handle, &conversation.meta(agent, sender))?;
+                    conversation.handle = Some(handle);
+                }
+            }
+        }
+
+        self.conversations.write().await.insert(id, slot);
+        Ok(SwitchOutcome {
+            conversation_id: id,
+            resumed,
+        })
+    }
+
+    async fn rollback_topic_reservation(&self, key: &(String, String), title: &str) {
+        let mut topics = self.topics.write().await;
+        let Some(router) = topics.get_mut(key) else {
+            return;
+        };
+        router.by_title.remove(title);
+        if router.active.as_deref() == Some(title) {
+            router.active = None;
+        }
+        if router.by_title.is_empty() && router.active.is_none() && router.tmp.is_none() {
+            topics.remove(key);
+        }
+    }
+
+    /// Scan storage for a session matching `(agent, sender, topic)`.
+    /// Blocking I/O; call from outside the runtime locks.
+    fn find_topic_session(
+        &self,
+        agent: &str,
+        sender: &str,
+        title: &str,
+    ) -> Option<(SessionHandle, wcore::storage::SessionSnapshot)> {
+        let storage = self.storage();
+        let summaries = storage.list_sessions().ok()?;
+        let mut match_: Option<(SessionHandle, wcore::storage::ConversationMeta)> = None;
+        for summary in summaries {
+            if summary.meta.agent != agent || summary.meta.created_by != sender {
+                continue;
+            }
+            if summary.meta.topic.as_deref() != Some(title) {
+                continue;
+            }
+            // Later sessions win — `created_at` is an RFC3339 string so
+            // lexicographic comparison is chronological.
+            if match_
+                .as_ref()
+                .is_none_or(|(_, meta)| summary.meta.created_at > meta.created_at)
+            {
+                match_ = Some((summary.handle, summary.meta));
+            }
+        }
+        let (handle, _) = match_?;
+        let snapshot = storage.load_session(&handle).ok().flatten()?;
+        Some((handle, snapshot))
+    }
+
+    /// Write the Topic memory entry if it doesn't already exist.
+    /// Duplicate-name errors are ignored — a prior process may have
+    /// created the same topic.
+    fn ensure_topic_entry(&self, title: &str, description: &str) {
+        let mut mem = self.memory.write();
+        if mem.get(title).is_some() {
+            return;
+        }
+        if let Err(e) = mem.apply(Op::Add {
+            name: title.to_owned(),
+            content: description.to_owned(),
+            aliases: vec![],
+            kind: EntryKind::Topic,
+        }) {
+            tracing::warn!("topic entry write failed: {e}");
+        }
+    }
+}

--- a/crates/runtime/src/engine/topic.rs
+++ b/crates/runtime/src/engine/topic.rs
@@ -4,13 +4,12 @@
 //! title, plus an active-topic pointer. Untopicked chats are tmp and
 //! live only in [`TopicRouter::tmp`]; they never reach storage.
 
+use super::Runtime;
 use crate::{Config, ConversationHandle};
 use anyhow::{Result, bail};
 use memory::{EntryKind, Op};
 use std::{collections::HashMap, sync::atomic::Ordering};
 use wcore::storage::Storage;
-
-use super::Runtime;
 
 /// Per-(agent, sender) topic routing. `active = None` means the caller
 /// is on a tmp chat (no topic). Tmp chats have their own `ConvSlot` but

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -4,7 +4,7 @@ pub mod env;
 pub mod hook;
 
 pub use conversation::Conversation;
-pub use engine::{Runtime, SharedMemory};
+pub use engine::{Runtime, SharedMemory, SwitchOutcome};
 pub use env::Env;
 pub use hook::Hook;
 pub use wcore::{MemoryConfig, SystemConfig, TasksConfig};

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -9,6 +9,11 @@ pub use env::Env;
 pub use hook::Hook;
 pub use wcore::{MemoryConfig, SystemConfig, TasksConfig};
 
+/// Opaque persistent handle to a conversation. Re-exported from the
+/// storage trait so runtime callers don't need to speak the storage
+/// layer's "session" vocabulary.
+pub type ConversationHandle = wcore::storage::SessionHandle;
+
 use crabllm_core::Provider;
 use wcore::storage::Storage;
 

--- a/crates/runtime/tests/engine.rs
+++ b/crates/runtime/tests/engine.rs
@@ -287,9 +287,12 @@ async fn stream_to_yields_correct_content() {
 }
 
 #[tokio::test]
-async fn resume_prepends_archive_content_from_memory() {
+async fn switch_active_topic_resumes_archive_from_memory() {
     use memory::{EntryKind, Op};
-    use wcore::{model::HistoryEntry, storage::Storage};
+    use wcore::{
+        model::HistoryEntry,
+        storage::{ConversationMeta, Storage},
+    };
 
     let storage = Arc::new(InMemoryStorage::new());
     let mem = Arc::new(parking_lot::RwLock::new(memory::Memory::new()));
@@ -303,6 +306,15 @@ async fn resume_prepends_archive_content_from_memory() {
         .unwrap();
 
     let handle = storage.create_session("crab", "tester").unwrap();
+    let topic_meta = ConversationMeta {
+        agent: "crab".into(),
+        created_by: "tester".into(),
+        created_at: chrono::Utc::now().to_rfc3339(),
+        title: String::new(),
+        uptime_secs: 0,
+        topic: Some("auth".into()),
+    };
+    storage.update_session_meta(&handle, &topic_meta).unwrap();
     storage
         .append_session_messages(
             &handle,
@@ -328,6 +340,10 @@ async fn resume_prepends_archive_content_from_memory() {
     );
     runtime.add_agent(AgentConfig::new("crab"));
 
+    runtime
+        .switch_active_topic("crab", "tester", "auth", None)
+        .await
+        .unwrap();
     let conv_id = runtime
         .get_or_create_conversation("crab", "tester")
         .await
@@ -335,20 +351,33 @@ async fn resume_prepends_archive_content_from_memory() {
     let conversation = runtime.conversation(conv_id).await.unwrap();
     let conv = conversation.lock().await;
 
+    assert_eq!(conv.topic.as_deref(), Some("auth"));
     assert_eq!(conv.history.len(), 2);
     assert_eq!(conv.history[0].text(), "earlier context, compacted");
     assert_eq!(conv.history[1].text(), "after-compact");
 }
 
 #[tokio::test]
-async fn resume_injects_placeholder_when_archive_missing() {
-    use wcore::{model::HistoryEntry, storage::Storage};
+async fn switch_active_topic_injects_placeholder_when_archive_missing() {
+    use wcore::{
+        model::HistoryEntry,
+        storage::{ConversationMeta, Storage},
+    };
 
     let storage = Arc::new(InMemoryStorage::new());
     // Empty memory — the referenced archive doesn't exist.
     let mem = Arc::new(parking_lot::RwLock::new(memory::Memory::new()));
 
     let handle = storage.create_session("crab", "tester").unwrap();
+    let topic_meta = ConversationMeta {
+        agent: "crab".into(),
+        created_by: "tester".into(),
+        created_at: chrono::Utc::now().to_rfc3339(),
+        title: String::new(),
+        uptime_secs: 0,
+        topic: Some("ghost".into()),
+    };
+    storage.update_session_meta(&handle, &topic_meta).unwrap();
     storage
         .append_session_compact(&handle, "archive-gone")
         .unwrap();
@@ -365,6 +394,10 @@ async fn resume_injects_placeholder_when_archive_missing() {
     );
     runtime.add_agent(AgentConfig::new("crab"));
 
+    runtime
+        .switch_active_topic("crab", "tester", "ghost", None)
+        .await
+        .unwrap();
     let conv_id = runtime
         .get_or_create_conversation("crab", "tester")
         .await

--- a/crates/runtime/tests/engine.rs
+++ b/crates/runtime/tests/engine.rs
@@ -112,7 +112,7 @@ async fn get_or_create_conversation_requires_registered_agent() {
 }
 
 #[tokio::test]
-async fn create_and_close_conversation() {
+async fn create_and_close() {
     let runtime = runtime(TestProvider::with_chunks(vec![]));
     runtime.add_agent(AgentConfig::new("crab"));
 
@@ -122,9 +122,9 @@ async fn create_and_close_conversation() {
         .unwrap();
     assert!(runtime.conversation(id).await.is_some());
 
-    assert!(runtime.close_conversation(id).await);
+    assert!(runtime.close(id).await);
     assert!(runtime.conversation(id).await.is_none());
-    assert!(!runtime.close_conversation(id).await);
+    assert!(!runtime.close(id).await);
 }
 
 #[tokio::test]
@@ -173,7 +173,7 @@ async fn get_or_create_conversation_rejects_unknown_agent() {
 }
 
 #[tokio::test]
-async fn transfer_conversations_moves_all() {
+async fn transfer_to_moves_all() {
     let runtime1 = runtime(TestProvider::with_chunks(vec![]));
     runtime1.add_agent(AgentConfig::new("crab"));
     let id = runtime1
@@ -183,7 +183,7 @@ async fn transfer_conversations_moves_all() {
 
     let mut runtime2 = runtime(TestProvider::with_chunks(vec![]));
     runtime2.add_agent(AgentConfig::new("crab"));
-    runtime1.transfer_conversations(&mut runtime2).await;
+    runtime1.transfer_to(&mut runtime2).await;
 
     // Conversation should exist in runtime2
     assert!(runtime2.conversation(id).await.is_some());
@@ -287,7 +287,7 @@ async fn stream_to_yields_correct_content() {
 }
 
 #[tokio::test]
-async fn switch_active_topic_resumes_archive_from_memory() {
+async fn switch_topic_resumes_archive_from_memory() {
     use memory::{EntryKind, Op};
     use wcore::{
         model::HistoryEntry,
@@ -341,7 +341,7 @@ async fn switch_active_topic_resumes_archive_from_memory() {
     runtime.add_agent(AgentConfig::new("crab"));
 
     runtime
-        .switch_active_topic("crab", "tester", "auth", None)
+        .switch_topic("crab", "tester", "auth", None)
         .await
         .unwrap();
     let conv_id = runtime
@@ -358,7 +358,7 @@ async fn switch_active_topic_resumes_archive_from_memory() {
 }
 
 #[tokio::test]
-async fn switch_active_topic_injects_placeholder_when_archive_missing() {
+async fn switch_topic_injects_placeholder_when_archive_missing() {
     use wcore::{
         model::HistoryEntry,
         storage::{ConversationMeta, Storage},
@@ -395,7 +395,7 @@ async fn switch_active_topic_injects_placeholder_when_archive_missing() {
     runtime.add_agent(AgentConfig::new("crab"));
 
     runtime
-        .switch_active_topic("crab", "tester", "ghost", None)
+        .switch_topic("crab", "tester", "ghost", None)
         .await
         .unwrap();
     let conv_id = runtime

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -29,4 +29,5 @@
 - [0121 - Event Bus](rfcs/0121-event-bus.md)
 - [0135 - Agent-First Protocol](rfcs/0135-agent-first.md)
 - [0150 - Memory Store](rfcs/0150-memory-store.md)
+- [0171 - Topic Switching](rfcs/0171-topic-switching.md)
 - [Superseded](rfcs/superseded.md)

--- a/docs/src/rfcs/0171-topic-switching.md
+++ b/docs/src/rfcs/0171-topic-switching.md
@@ -1,0 +1,88 @@
+# 0171 - Topic Switching
+
+- Feature Name: Topic Switching
+- Start Date: 2026-04-19
+- Discussion: [#171](https://github.com/crabtalk/crabtalk/issues/171)
+- Crates: memory, runtime, crabtalk
+- Updates: [0135 (Agent-First)](0135-agent-first.md), [0150 (Memory Store)](0150-memory-store.md)
+
+## Summary
+
+Topic switching is a first-class conversation boundary: the agent can partition its work with a person into parallel threads, each with its own history and compaction archive. Agent-First (0135) established `(agent, sender)` as the conversation key; this RFC layers `topic` on top so one `(agent, sender)` pair maps to N conversations keyed by title, plus an active-topic pointer. A new tool pair — `search_topics` and `switch_topic` — lets the agent drive it. Untopicked chats are tmp: in-memory only, no storage I/O, dropped at the end of the run.
+
+## Motivation
+
+Compaction is the only conversation boundary we had before this work, and it's the wrong tool for the job. Compaction is context-window management — it fires when the transcript gets full, not when the topic changes. Work on auth and work on the deploy pipeline end up in the same conversation history, competing for the same context window, confusing each other.
+
+Compact and topic-switch are different mechanisms:
+
+- **Compact** is intra-conversation. Summarize the current thread, archive the summary, keep going. Same conversation id, same active state.
+- **Topic switch** is inter-conversation. Pause this thread (full context preserved), pick up another. No summarization, no archive. Each topic is a conversation with its own compaction history.
+
+## Design
+
+### Tools
+
+Two new agent tools:
+
+- `search_topics(query)` — BM25 search over existing topics. Returns ranked `(title, description)` pairs. Not a `list_topics` dump — the agent searches, not browses, same as `recall`.
+- `switch_topic(title, description?)` — exact title match resumes that conversation and makes it active; no match creates a new conversation with this title. `description` is required on create, ignored on resume.
+
+Free-form titles, agent-chosen. The title *is* the key.
+
+### Agent-written descriptions
+
+When the agent creates a new topic, it supplies a short description — one to three sentences on what the topic is about. That description becomes the `content` of the memory entry and is what BM25 actually indexes. Title alone is too short for useful recall; auto-summarization from conversation content would need an LLM round-trip per switch and drift as the conversation evolves. The description is immutable after creation — if the focus shifts, the agent switches to a new topic rather than rewriting the label.
+
+### Memory integration
+
+Topics piggyback on the memory crate. A new `EntryKind::Topic` variant joins `Note` and `Archive`. Each topic materializes as a memory entry:
+
+- `name` = the topic title
+- `content` = the agent-written description
+- `kind` = `EntryKind::Topic`
+
+`search_topics` is implemented as `Memory::search_kind(query, limit, EntryKind::Topic)` — one BM25 index, one ranking story. When the scope-weighting work in #170 lands, recency decay means recently-touched topics rank above stale ones for free.
+
+### Runtime routing
+
+The daemon tracks, per `(agent, sender)`:
+
+- `TopicRouter { by_title: HashMap<String, ConversationId>, active: Option<String>, tmp: Option<ConversationId> }`
+
+`get_or_create_conversation(agent, sender)` routes in order:
+
+1. If `router.active = Some(title)` and the title is in `by_title`, return that conversation.
+2. Otherwise, return or create the tmp conversation.
+
+Protocol surface is unchanged: clients still address `(agent, sender)` and `StreamMsg` gains no topic field. The daemon routes to the active topic's conversation; the agent owns topic decisions; the user just talks to the agent.
+
+### Tmp chats are not persisted
+
+A conversation with no topic has no session handle. `ensure_handle` refuses to create one for tmp chats, and `persist_messages` no-ops without a handle. This is a deliberate, backward-incompatible break from Agent-First, which always auto-resumed the latest session on first message. Under the new model:
+
+- A user who never switches to a topic never persists anything. Their work is in-memory for the life of the run, then gone.
+- A user who wants continuity calls `switch_topic`. That session is persisted; prior topic sessions for the same `(agent, sender, title)` are resumed via a `list_sessions()` scan on cold switch.
+
+This trades reflexive persistence for agent-controlled persistence. The agent now has to decide what's worth keeping, which is the right place for that decision.
+
+### Cold-path concurrency
+
+`switch_active_topic` on an unknown title would otherwise race: two callers both miss the fast path, both do storage I/O, both `create_session`, second clobbers first. Fix: reserve the conversation id under the router's write lock *before* any I/O. Any concurrent caller sees the reservation and resumes to the same conversation instead of creating a duplicate. If the I/O subsequently fails, the reservation is rolled back.
+
+### Compaction per topic
+
+Each topic compacts independently. The existing `AgentConfig::compact_threshold` fires on the active topic's conversation and writes an `EntryKind::Archive` entry scoped to that topic — exactly as today, just per-topic instead of per-`(agent, sender)`.
+
+Archives are named `{topic-slug}-{n}` where `n` is the next free sequence number for this topic. Older archives stay searchable via `recall` instead of being overwritten, so the agent can surface older phases of a long-running topic when they're relevant. Scan and insert happen under one memory write lock so two concurrent compactions can't pick the same sequence.
+
+Resume auto-prepends the right archive: `load_session` returns the most recent compact marker, `resumed_history` looks that archive up in memory and injects its content as the replayed prefix. Topic switching just changes which conversation is active; the resume mechanism is unchanged.
+
+`switch_topic` does **not** implicitly compact. If a resumed topic is close to threshold, normal auto-compaction fires on the next turn — late enough to stay cheap, early enough to matter.
+
+Downstream ranking work lives in [#170](https://github.com/crabtalk/crabtalk/issues/170): topic becomes a new scope dimension (same-topic boost, related-topic BM25 similarity) when that RFC lands.
+
+## Open questions
+
+- **Deletion.** Forgetting a topic entry via `forget` orphans the underlying conversation (runtime keeps the router until process exit). Whether a topic should be truly deletable — and what happens to its archive history — is deferred.
+- **Cross-restart active-topic memory.** The active-topic pointer lives only in the running process. On restart, every `(agent, sender)` starts in tmp until the agent re-enters a topic. Rebuilding "last active topic per pair" from storage is doable but not part of this RFC.


### PR DESCRIPTION
Closes #171.

## What

Agents can now split their work with a person into parallel threads called **topics**. Each topic is its own conversation with its own history and compaction archive; untopicked chats are tmp and not persisted. Two new tools — `search_topics` and `switch_topic` — let the agent drive it. Compaction is unchanged; topics layer on top so one `(agent, sender)` pair maps to N conversations keyed by title, with an active-topic pointer.

## How

- **memory:** new `EntryKind::Topic` + `Memory::search_kind` for kind-filtered BM25. Topic entries carry agent-written descriptions that get indexed.
- **runtime:** `(agent, sender) → TopicRouter { by_title, active, tmp }` routing. `switch_active_topic` reserves its slot under the router write lock *before* I/O so concurrent switches can't race on `create_session`. `ensure_handle` refuses to persist tmp chats — entering a topic is how the agent promotes work into long-term memory. Backward-incompatible break from Agent-First: `get_or_create_conversation` no longer auto-resumes the latest session.
- **hooks:** new `TopicHook` in `crates/crabtalk/src/hooks/topic/` with per-tool files, wired into `DaemonHook` alongside memory.
- **archives:** renamed from `archive-{session}-{nanos}` to `{topic-slug}-{n}`. Sequence + memory write lock means concurrent compactions can't collide and older phases of a long topic stay searchable.
- **docs:** behavioural prompt at `crates/crabtalk/prompts/topic.md`, design RFC at `docs/src/rfcs/0171-topic-switching.md`.

## Test plan

- [x] `cargo nextest run --workspace` — 175/175 pass
- [x] `cargo fmt` / `cargo build --workspace` clean
- [ ] Manual: fresh daemon, send first message (tmp), `switch_topic("auth", "...")`, restart daemon, `switch_topic("auth")` resumes prior history
- [ ] Manual: trigger compaction twice on one topic, confirm archives are `{slug}-1` and `{slug}-2` and both are `recall`-able