### PR TITLE
feat(mcp): observable lifecycle with status, targeted reconnect, and events

### DIFF
--- a/apps/daemon/src/lib.rs
+++ b/apps/daemon/src/lib.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use transport::Transport;
 use wcore::protocol::{
     api::Client,
-    message::{AgentEventKind, plugin_event},
+    message::{AgentEventKind, McpEventKind, plugin_event},
 };
 
 pub mod attach;
@@ -44,6 +44,8 @@ pub enum Command {
     Reload,
     /// Stream daemon events.
     Events,
+    /// Stream MCP server lifecycle events.
+    McpEvents,
     /// Install a plugin.
     Pull {
         /// Plugin name.
@@ -84,6 +86,7 @@ impl Cli {
                 Ok(())
             }
             Command::Events => stream_events(connect(self.tcp).await?).await,
+            Command::McpEvents => stream_mcp_events(connect(self.tcp).await?).await,
             Command::Pull { plugin, force } => {
                 use std::io::Write;
                 let mut conn = connect(self.tcp).await?;
@@ -202,6 +205,29 @@ async fn stream_events(mut conn: Transport) -> Result<()> {
                 }
             }
         }
+    }
+    Ok(())
+}
+
+/// Stream MCP lifecycle events to stdout.
+async fn stream_mcp_events(mut conn: Transport) -> Result<()> {
+    let stream = conn.subscribe_mcp_events();
+    tokio::pin!(stream);
+    while let Some(result) = stream.next().await {
+        let event = result?;
+        let kind = match McpEventKind::try_from(event.kind) {
+            Ok(McpEventKind::Connecting) => "connecting",
+            Ok(McpEventKind::Connected) => "connected",
+            Ok(McpEventKind::Failed) => "failed",
+            Ok(McpEventKind::Disconnected) => "disconnected",
+            _ => "unknown",
+        };
+        let detail = match McpEventKind::try_from(event.kind) {
+            Ok(McpEventKind::Connected) => format!(" ({} tool(s))", event.tools.len()),
+            Ok(McpEventKind::Failed) if !event.error.is_empty() => format!(": {}", event.error),
+            _ => String::new(),
+        };
+        println!("[{}] {} {}{}", event.timestamp, event.name, kind, detail);
     }
     Ok(())
 }

--- a/crates/core/proto/crabtalk.proto
+++ b/crates/core/proto/crabtalk.proto
@@ -601,6 +601,7 @@ enum McpStatus {
   CONNECTED = 1;
   DISCONNECTED = 2;
   FAILED = 3;
+  CONNECTING = 4;
 }
 
 message McpInfo {

--- a/crates/core/proto/crabtalk.proto
+++ b/crates/core/proto/crabtalk.proto
@@ -79,6 +79,8 @@ message ClientMessage {
     PublishEventMsg publish_event = 43;
     // Steering
     SteerSessionMsg steer_session = 44;
+    // MCP lifecycle event subscription
+    SubscribeMcpEventsMsg subscribe_mcp_events = 52;
     // Extension point for downstream products.
     bytes extension = 100;
   }
@@ -325,6 +327,8 @@ message ServerMessage {
     SubscriptionList subscription_list = 26;
     // MCP CRUD response (single-item)
     McpInfo mcp_info = 29;
+    // MCP lifecycle event
+    McpEventMsg mcp_event = 30;
     // Extension point for downstream products.
     bytes extension = 100;
   }
@@ -623,6 +627,26 @@ message McpInfo {
 
 message McpList {
   repeated McpInfo mcps = 1;
+}
+
+message SubscribeMcpEventsMsg {}
+
+enum McpEventKind {
+  MCP_EVENT_KIND_UNKNOWN = 0;
+  MCP_EVENT_KIND_CONNECTING = 1;
+  MCP_EVENT_KIND_CONNECTED = 2;
+  MCP_EVENT_KIND_FAILED = 3;
+  MCP_EVENT_KIND_DISCONNECTED = 4;
+}
+
+message McpEventMsg {
+  McpEventKind kind = 1;
+  string name = 2;
+  // Populated for CONNECTED.
+  repeated string tools = 3;
+  // Populated for FAILED.
+  string error = 4;
+  string timestamp = 5;
 }
 
 // ── Plugin Events ───────────────────────────────────────────────

--- a/crates/core/src/protocol/api/client.rs
+++ b/crates/core/src/protocol/api/client.rs
@@ -945,6 +945,27 @@ pub trait Client: Send {
         })
     }
 
+    /// Subscribe to MCP lifecycle events.
+    fn subscribe_mcp_events(&mut self) -> impl Stream<Item = Result<McpEventMsg>> + Send + '_ {
+        self.request_stream(ClientMessage {
+            msg: Some(client_message::Msg::SubscribeMcpEvents(
+                SubscribeMcpEventsMsg {},
+            )),
+        })
+        .filter_map(|r| async {
+            match r {
+                Ok(ServerMessage {
+                    msg: Some(server_message::Msg::McpEvent(e)),
+                }) => Some(Ok(e)),
+                Ok(ServerMessage {
+                    msg: Some(server_message::Msg::Error(ErrorMsg { code, message })),
+                }) => Some(Err(anyhow::anyhow!("server error ({code}): {message}"))),
+                Ok(_) => None,
+                Err(e) => Some(Err(e)),
+            }
+        })
+    }
+
     /// Inject a user message into an active stream (steering).
     fn steer_session(
         &mut self,

--- a/crates/core/src/protocol/api/server.rs
+++ b/crates/core/src/protocol/api/server.rs
@@ -3,11 +3,11 @@
 use crate::protocol::message::{
     ActiveConversationInfo, ActiveConversationList, AgentEventMsg, AgentInfo, AgentList,
     ClientMessage, CompactResponse, ConversationHistory, ConversationInfo, ConversationList,
-    CreateAgentMsg, DaemonStats, ErrorMsg, InstallPluginMsg, McpInfo, McpList, ModelInfo,
-    ModelList, PluginEvent, PluginInfo, PluginList, PluginSearchList, Pong, PublishEventMsg,
-    SendMsg, SendResponse, ServerMessage, ServiceLogOutput, SkillInfo, SkillList, SteerSessionMsg,
-    StreamEvent, StreamMsg, SubscribeEventMsg, SubscriptionInfo, SubscriptionList, UpdateAgentMsg,
-    UpsertMcpMsg, client_message, server_message,
+    CreateAgentMsg, DaemonStats, ErrorMsg, InstallPluginMsg, McpEventMsg, McpInfo, McpList,
+    ModelInfo, ModelList, PluginEvent, PluginInfo, PluginList, PluginSearchList, Pong,
+    PublishEventMsg, SendMsg, SendResponse, ServerMessage, ServiceLogOutput, SkillInfo, SkillList,
+    SteerSessionMsg, StreamEvent, StreamMsg, SubscribeEventMsg, SubscriptionInfo, SubscriptionList,
+    UpdateAgentMsg, UpsertMcpMsg, client_message, server_message,
 };
 use anyhow::Result;
 use futures_core::Stream;
@@ -68,6 +68,9 @@ pub trait Server: Sync {
 
     /// Handle `SubscribeEvents` — stream agent events.
     fn subscribe_events(&self) -> impl Stream<Item = Result<AgentEventMsg>> + Send;
+
+    /// Handle `SubscribeMcpEvents` — stream MCP lifecycle events.
+    fn subscribe_mcp_events(&self) -> impl Stream<Item = Result<McpEventMsg>> + Send;
 
     /// Handle `Reload` — hot-reload runtime from disk.
     fn reload(&self) -> impl std::future::Future<Output = Result<()>> + Send;
@@ -287,6 +290,13 @@ pub trait Server: Sync {
                 }
                 client_message::Msg::SubscribeEvents(_) => {
                     let s = self.subscribe_events();
+                    tokio::pin!(s);
+                    while let Some(result) = s.next().await {
+                        yield result_to_msg(result);
+                    }
+                }
+                client_message::Msg::SubscribeMcpEvents(_) => {
+                    let s = self.subscribe_mcp_events();
                     tokio::pin!(s);
                     while let Some(result) = s.next().await {
                         yield result_to_msg(result);

--- a/crates/core/src/protocol/message/convert.rs
+++ b/crates/core/src/protocol/message/convert.rs
@@ -2,9 +2,9 @@
 
 use crate::agent::AgentConfig;
 use crate::protocol::proto::{
-    AgentEventMsg, AgentInfo, ClientMessage, ConversationHistory, PluginEvent, ReplyToAsk, SendMsg,
-    SendResponse, ServerMessage, StreamEvent, StreamMsg, client_message, plugin_event,
-    server_message, stream_event,
+    AgentEventMsg, AgentInfo, ClientMessage, ConversationHistory, McpEventMsg, PluginEvent,
+    ReplyToAsk, SendMsg, SendResponse, ServerMessage, StreamEvent, StreamMsg, client_message,
+    plugin_event, server_message, stream_event,
 };
 
 impl From<&AgentConfig> for AgentInfo {
@@ -71,6 +71,14 @@ impl From<AgentEventMsg> for ServerMessage {
     fn from(e: AgentEventMsg) -> Self {
         Self {
             msg: Some(server_message::Msg::AgentEvent(e)),
+        }
+    }
+}
+
+impl From<McpEventMsg> for ServerMessage {
+    fn from(e: McpEventMsg) -> Self {
+        Self {
+            msg: Some(server_message::Msg::McpEvent(e)),
         }
     }
 }

--- a/crates/crabtalk/src/daemon/builder.rs
+++ b/crates/crabtalk/src/daemon/builder.rs
@@ -261,7 +261,6 @@ impl<P: Provider + 'static> Daemon<P> {
         let memory = Arc::new(memory_wrapper);
         let scopes = node_hook.scopes.clone();
         let read_files: crate::hooks::os::ReadFiles = Default::default();
-        let mcp_server_list = mcp_handler.cached_list();
         let skills = storage.list_skills().await.unwrap_or_default();
 
         let os_hook = Arc::new(crate::hooks::os::OsHook::new(
@@ -301,24 +300,10 @@ impl<P: Provider + 'static> Daemon<P> {
         let ask_hook = Arc::new(crate::hooks::ask_user::AskUserHook::new(pending_asks));
         node_hook.register_hook("ask_user", ask_hook.clone());
 
-        if !mcp_server_list.is_empty() {
-            let mcp_prompt = format!(
-                "\n\n<resources>\nMCP servers: {}. Use the mcp tool to list or call tools.\n</resources>",
-                mcp_server_list
-                    .iter()
-                    .map(|(n, _)| n.as_str())
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            );
-            node_hook.register_hook(
-                "mcp",
-                Arc::new(crate::hooks::mcp::McpHook::new(
-                    mcp_handler,
-                    scopes,
-                    mcp_prompt,
-                )),
-            );
-        }
+        node_hook.register_hook(
+            "mcp",
+            Arc::new(crate::hooks::mcp::McpHook::new(mcp_handler, scopes)),
+        );
         Ok((os_hook, ask_hook, shared_memory))
     }
 

--- a/crates/crabtalk/src/hooks/mcp.rs
+++ b/crates/crabtalk/src/hooks/mcp.rs
@@ -24,20 +24,11 @@ pub struct Mcp {
 pub struct McpHook {
     mcp: Arc<McpHandler>,
     scopes: Arc<RwLock<BTreeMap<String, AgentScope>>>,
-    prompt: String,
 }
 
 impl McpHook {
-    pub fn new(
-        mcp: Arc<McpHandler>,
-        scopes: Arc<RwLock<BTreeMap<String, AgentScope>>>,
-        prompt: String,
-    ) -> Self {
-        Self {
-            mcp,
-            scopes,
-            prompt,
-        }
+    pub fn new(mcp: Arc<McpHandler>, scopes: Arc<RwLock<BTreeMap<String, AgentScope>>>) -> Self {
+        Self { mcp, scopes }
     }
 }
 
@@ -61,7 +52,14 @@ impl Hook for McpHook {
     }
 
     fn system_prompt(&self) -> Option<String> {
-        Some(self.prompt.clone())
+        let names: Vec<String> = self.mcp.cached_list().into_iter().map(|(n, _)| n).collect();
+        if names.is_empty() {
+            return None;
+        }
+        Some(format!(
+            "\n\n<resources>\nMCP servers: {}. Use the mcp tool to list or call tools.\n</resources>",
+            names.join(", ")
+        ))
     }
 
     fn dispatch<'a>(&'a self, name: &'a str, call: ToolDispatch) -> Option<ToolFuture<'a>> {

--- a/crates/crabtalk/src/protocol/admin.rs
+++ b/crates/crabtalk/src/protocol/admin.rs
@@ -5,10 +5,45 @@ use crate::daemon::Daemon;
 use crate::daemon::event::EventSubscription;
 use anyhow::Result;
 use crabllm_core::Provider;
+use mcp::McpEvent;
 use runtime::Env;
 use std::collections::VecDeque;
 use std::io::{BufRead, BufReader};
 use wcore::protocol::message::*;
+
+fn mcp_event_to_msg(event: McpEvent) -> McpEventMsg {
+    let now = chrono::Utc::now().to_rfc3339();
+    match event {
+        McpEvent::Connecting { name } => McpEventMsg {
+            kind: McpEventKind::Connecting.into(),
+            name,
+            tools: Vec::new(),
+            error: String::new(),
+            timestamp: now,
+        },
+        McpEvent::Connected { name, tools } => McpEventMsg {
+            kind: McpEventKind::Connected.into(),
+            name,
+            tools,
+            error: String::new(),
+            timestamp: now,
+        },
+        McpEvent::Failed { name, error } => McpEventMsg {
+            kind: McpEventKind::Failed.into(),
+            name,
+            tools: Vec::new(),
+            error,
+            timestamp: now,
+        },
+        McpEvent::Disconnected { name } => McpEventMsg {
+            kind: McpEventKind::Disconnected.into(),
+            name,
+            tools: Vec::new(),
+            error: String::new(),
+            timestamp: now,
+        },
+    }
+}
 
 impl<P: Provider + 'static> Daemon<P> {
     pub(crate) async fn get_stats(&self) -> Result<DaemonStats> {
@@ -37,6 +72,22 @@ impl<P: Provider + 'static> Daemon<P> {
             loop {
                 match rx.recv().await {
                     Ok(event) => yield event,
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                }
+            }
+        }
+    }
+
+    pub(crate) fn subscribe_mcp_events(
+        &self,
+    ) -> impl futures_core::Stream<Item = Result<McpEventMsg>> + Send {
+        let mcp = self.mcp.clone();
+        async_stream::try_stream! {
+            let mut rx = mcp.subscribe();
+            loop {
+                match rx.recv().await {
+                    Ok(event) => yield mcp_event_to_msg(event),
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
                 }

--- a/crates/crabtalk/src/protocol/config.rs
+++ b/crates/crabtalk/src/protocol/config.rs
@@ -3,6 +3,8 @@
 use crate::daemon::Daemon;
 use anyhow::{Context, Result};
 use crabllm_core::Provider;
+use mcp::{McpServerState, ServerStatus};
+use std::collections::BTreeMap;
 use wcore::protocol::message::*;
 use wcore::storage::Storage;
 
@@ -29,12 +31,7 @@ impl<P: Provider + 'static> Daemon<P> {
     }
 
     pub(crate) async fn list_mcps(&self) -> Result<Vec<McpInfo>> {
-        let connected: std::collections::BTreeMap<String, usize> = self
-            .mcp
-            .cached_list()
-            .into_iter()
-            .map(|(name, tools)| (name, tools.len()))
-            .collect();
+        let states = self.mcp.states();
         let storage_mcps = {
             let rt = self.runtime.read().await.clone();
             rt.storage().list_mcps().await?
@@ -42,12 +39,12 @@ impl<P: Provider + 'static> Daemon<P> {
         // Storage wins over manifest on name conflict — seed the map from
         // storage first, then `entry(..).or_insert_with` for manifest entries
         // skips names already present. Output is alphabetical by name.
-        let mut by_name: std::collections::BTreeMap<String, McpInfo> = storage_mcps
+        let mut by_name: BTreeMap<String, McpInfo> = storage_mcps
             .iter()
             .map(|(name, cfg)| {
                 (
                     name.clone(),
-                    mcp_info(name, cfg, "local", SourceKind::Local, &connected),
+                    mcp_info(name, cfg, "local", SourceKind::Local, &states),
                 )
             })
             .collect();
@@ -59,7 +56,7 @@ impl<P: Provider + 'static> Daemon<P> {
                         &mcp_res.to_server_config(),
                         &plugin_name,
                         SourceKind::Plugin,
-                        &connected,
+                        &states,
                     )
                 });
             }
@@ -138,11 +135,17 @@ fn mcp_info(
     cfg: &wcore::McpServerConfig,
     source: &str,
     source_kind: SourceKind,
-    connected: &std::collections::BTreeMap<String, usize>,
+    states: &BTreeMap<String, McpServerState>,
 ) -> McpInfo {
-    let (status, tool_count) = match connected.get(name) {
-        Some(&count) => (McpStatus::Connected, count as u32),
-        None => (McpStatus::Failed, 0),
+    let (status, tool_count, error) = match states.get(name) {
+        Some(state) => (
+            proto_status(state.status),
+            state.tools.len() as u32,
+            state.last_error.clone().unwrap_or_default(),
+        ),
+        // Registered in storage/plugin but never seen by the handler — treat
+        // as not yet attempted.
+        None => (McpStatus::Unknown, 0, String::new()),
     };
     McpInfo {
         name: name.to_string(),
@@ -159,7 +162,16 @@ fn mcp_info(
         auto_restart: cfg.auto_restart,
         source_kind: source_kind.into(),
         status: status.into(),
-        error: String::new(),
+        error,
         tool_count,
+    }
+}
+
+fn proto_status(s: ServerStatus) -> McpStatus {
+    match s {
+        ServerStatus::Connecting => McpStatus::Connecting,
+        ServerStatus::Connected => McpStatus::Connected,
+        ServerStatus::Failed => McpStatus::Failed,
+        ServerStatus::Disconnected => McpStatus::Disconnected,
     }
 }

--- a/crates/crabtalk/src/protocol/config.rs
+++ b/crates/crabtalk/src/protocol/config.rs
@@ -72,9 +72,10 @@ impl<P: Provider + 'static> Daemon<P> {
             let rt = self.runtime.read().await.clone();
             rt.storage().upsert_mcp(&cfg).await?;
         }
-        self.reload().await?;
+        self.mcp.upsert_server(&cfg).await;
 
-        // Re-list to surface the runtime status (connected/failed/etc).
+        // Re-list to surface the runtime status (connected/failed/etc) merged
+        // with the per-source view (storage vs plugin manifest).
         let mcps = self.list_mcps().await?;
         mcps.into_iter()
             .find(|m| m.name == name)
@@ -87,7 +88,7 @@ impl<P: Provider + 'static> Daemon<P> {
             rt.storage().delete_mcp(name).await?
         };
         if removed {
-            self.reload().await?;
+            self.mcp.disconnect_server(name).await;
         }
         Ok(removed)
     }

--- a/crates/crabtalk/src/protocol/mod.rs
+++ b/crates/crabtalk/src/protocol/mod.rs
@@ -62,6 +62,10 @@ impl<P: Provider + 'static> Server for Daemon<P> {
         self.subscribe_events()
     }
 
+    fn subscribe_mcp_events(&self) -> impl futures_core::Stream<Item = Result<McpEventMsg>> + Send {
+        self.subscribe_mcp_events()
+    }
+
     async fn reload(&self) -> Result<()> {
         self.reload().await
     }

--- a/crates/mcp/src/handler.rs
+++ b/crates/mcp/src/handler.rs
@@ -2,15 +2,66 @@
 
 use crate::McpBridge;
 use parking_lot::RwLock as SyncRwLock;
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 use tokio::sync::RwLock;
 use wcore::McpServerConfig;
+
+/// Connection status for a single registered MCP server.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServerStatus {
+    /// Connect attempt in progress.
+    Connecting,
+    /// Connected and tools registered.
+    Connected,
+    /// Connect attempt failed; see `last_error` on the state.
+    Failed,
+    /// Previously connected, now removed (kept on the map for diagnostics).
+    Disconnected,
+}
+
+/// Per-server lifecycle state mirrored on the handler.
+///
+/// The bridge owns the live peer set; this map is the queryable view —
+/// it retains failures (which the bridge drops) and surfaces "currently
+/// trying" between attempts.
+#[derive(Debug, Clone)]
+pub struct McpServerState {
+    pub status: ServerStatus,
+    pub tools: Vec<String>,
+    pub last_error: Option<String>,
+}
+
+impl McpServerState {
+    fn connecting() -> Self {
+        Self {
+            status: ServerStatus::Connecting,
+            tools: Vec::new(),
+            last_error: None,
+        }
+    }
+
+    fn connected(tools: Vec<String>) -> Self {
+        Self {
+            status: ServerStatus::Connected,
+            tools,
+            last_error: None,
+        }
+    }
+
+    fn failed(error: String) -> Self {
+        Self {
+            status: ServerStatus::Failed,
+            tools: Vec::new(),
+            last_error: Some(error),
+        }
+    }
+}
 
 /// MCP bridge owner.
 pub struct McpHandler {
     bridge: RwLock<Arc<McpBridge>>,
-    /// Sync cache of server names → tool names, populated at load/reload.
-    server_cache: SyncRwLock<Vec<(String, Vec<String>)>>,
+    /// Per-server state, keyed by server name.
+    states: SyncRwLock<BTreeMap<String, McpServerState>>,
 }
 
 impl McpHandler {
@@ -18,7 +69,7 @@ impl McpHandler {
     pub fn empty() -> Self {
         Self {
             bridge: RwLock::new(Arc::new(McpBridge::new())),
-            server_cache: SyncRwLock::new(Vec::new()),
+            states: SyncRwLock::new(BTreeMap::new()),
         }
     }
 
@@ -26,113 +77,59 @@ impl McpHandler {
     /// Timeout for connecting to a single MCP server (30 seconds).
     const MCP_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
-    async fn build_bridge(configs: &[McpServerConfig]) -> McpBridge {
+    async fn build_bridge(
+        configs: &[McpServerConfig],
+    ) -> (McpBridge, BTreeMap<String, McpServerState>) {
         let bridge = McpBridge::new();
-        let mut connected_names: Vec<String> = Vec::new();
+        let mut states: BTreeMap<String, McpServerState> = BTreeMap::new();
 
         // 1. Connect servers from config.
         for server_config in configs {
-            let fut = async {
-                if let Some(url) = &server_config.url {
-                    tracing::info!(
-                        server = %server_config.name,
-                        url = %url,
-                        "connecting MCP server via HTTP"
-                    );
-                    bridge
-                        .connect_http_named(server_config.name.clone(), url)
-                        .await
-                } else {
-                    let mut cmd = tokio::process::Command::new(&server_config.command);
-                    cmd.args(&server_config.args);
-                    for (k, v) in &server_config.env {
-                        cmd.env(k, v);
-                    }
-                    tracing::info!(
-                        server = %server_config.name,
-                        command = %server_config.command,
-                        "connecting MCP server via stdio"
-                    );
-                    bridge
-                        .connect_stdio_named(server_config.name.clone(), cmd)
-                        .await
-                }
-            };
-
-            match tokio::time::timeout(Self::MCP_CONNECT_TIMEOUT, fut).await {
-                Ok(Ok(tools)) => {
-                    connected_names.push(server_config.name.clone());
-                    tracing::info!(
-                        "connected MCP server '{}' — {} tool(s)",
-                        server_config.name,
-                        tools.len()
-                    );
-                }
-                Ok(Err(e)) => {
-                    tracing::warn!("failed to connect MCP server '{}': {e}", server_config.name);
-                }
-                Err(_) => {
-                    tracing::warn!(
-                        "MCP server '{}' timed out after {}s, skipping",
-                        server_config.name,
-                        Self::MCP_CONNECT_TIMEOUT.as_secs()
-                    );
-                }
-            }
+            states.insert(server_config.name.clone(), McpServerState::connecting());
+            let state = connect_one(&bridge, server_config).await;
+            states.insert(server_config.name.clone(), state);
         }
 
-        // 2. Auto-discover services from port files not already connected.
+        // 2. Auto-discover services from port files not already registered.
         for (name, url) in scan_port_files() {
-            if connected_names.iter().any(|n| n == &name) {
+            if states.contains_key(&name) {
                 continue;
             }
-            tracing::info!(
-                server = %name,
-                url = %url,
-                "connecting MCP server via port file"
-            );
-            match tokio::time::timeout(
-                Self::MCP_CONNECT_TIMEOUT,
-                bridge.connect_http_named(name.clone(), &url),
-            )
-            .await
-            {
-                Ok(Ok(tools)) => {
-                    tracing::info!("connected MCP server '{name}' — {} tool(s)", tools.len());
-                }
-                Ok(Err(e)) => {
-                    tracing::warn!("failed to connect MCP server '{name}': {e}");
-                }
-                Err(_) => {
-                    tracing::warn!(
-                        "MCP server '{name}' timed out after {}s, skipping",
-                        Self::MCP_CONNECT_TIMEOUT.as_secs()
-                    );
-                }
-            }
+            states.insert(name.clone(), McpServerState::connecting());
+            let state = connect_http(&bridge, &name, &url).await;
+            states.insert(name, state);
         }
 
-        bridge
+        (bridge, states)
     }
 
     /// Load MCP servers from the given configs at startup.
     pub async fn load(configs: &[McpServerConfig]) -> Self {
-        let bridge = Self::build_bridge(configs).await;
-        let servers = bridge.list_servers().await;
+        let (bridge, states) = Self::build_bridge(configs).await;
         Self {
             bridge: RwLock::new(Arc::new(bridge)),
-            server_cache: SyncRwLock::new(servers),
+            states: SyncRwLock::new(states),
         }
     }
 
-    /// List all connected servers with their tool names.
+    /// List all connected servers with their tool names (live, from the bridge).
     pub async fn list(&self) -> Vec<(String, Vec<String>)> {
         self.bridge.read().await.list_servers().await
     }
 
-    /// Sync access to the cached server→tools list (populated at load time).
+    /// Sync access to the cached list of *connected* servers and their tools.
     pub fn cached_list(&self) -> Vec<(String, Vec<String>)> {
-        self.server_cache.read().clone()
+        self.states
+            .read()
+            .iter()
+            .filter(|(_, s)| s.status == ServerStatus::Connected)
+            .map(|(name, s)| (name.clone(), s.tools.clone()))
+            .collect()
+    }
+
+    /// Snapshot of every registered server's state (connected, failed, or other).
+    pub fn states(&self) -> BTreeMap<String, McpServerState> {
+        self.states.read().clone()
     }
 
     /// Get a clone of the current bridge Arc.
@@ -143,6 +140,81 @@ impl McpHandler {
     /// Try to get a clone of the current bridge Arc without blocking.
     pub fn try_bridge(&self) -> Option<Arc<McpBridge>> {
         self.bridge.try_read().ok().map(|g| Arc::clone(&*g))
+    }
+}
+
+/// Attempt to connect a single server, applying the global timeout.
+async fn connect_one(bridge: &McpBridge, cfg: &McpServerConfig) -> McpServerState {
+    let fut = async {
+        if let Some(url) = &cfg.url {
+            tracing::info!(server = %cfg.name, %url, "connecting MCP server via HTTP");
+            bridge.connect_http_named(cfg.name.clone(), url).await
+        } else {
+            let mut cmd = tokio::process::Command::new(&cfg.command);
+            cmd.args(&cfg.args);
+            for (k, v) in &cfg.env {
+                cmd.env(k, v);
+            }
+            tracing::info!(
+                server = %cfg.name,
+                command = %cfg.command,
+                "connecting MCP server via stdio"
+            );
+            bridge.connect_stdio_named(cfg.name.clone(), cmd).await
+        }
+    };
+
+    match tokio::time::timeout(McpHandler::MCP_CONNECT_TIMEOUT, fut).await {
+        Ok(Ok(tools)) => {
+            tracing::info!(
+                "connected MCP server '{}' — {} tool(s)",
+                cfg.name,
+                tools.len()
+            );
+            McpServerState::connected(tools)
+        }
+        Ok(Err(e)) => {
+            let msg = e.to_string();
+            tracing::warn!("failed to connect MCP server '{}': {msg}", cfg.name);
+            McpServerState::failed(msg)
+        }
+        Err(_) => {
+            let msg = format!(
+                "timed out after {}s",
+                McpHandler::MCP_CONNECT_TIMEOUT.as_secs()
+            );
+            tracing::warn!("MCP server '{}' {msg}, skipping", cfg.name);
+            McpServerState::failed(msg)
+        }
+    }
+}
+
+/// Attempt to connect via an already-known HTTP URL (port-file discovery).
+async fn connect_http(bridge: &McpBridge, name: &str, url: &str) -> McpServerState {
+    tracing::info!(server = %name, %url, "connecting MCP server via port file");
+    match tokio::time::timeout(
+        McpHandler::MCP_CONNECT_TIMEOUT,
+        bridge.connect_http_named(name.to_string(), url),
+    )
+    .await
+    {
+        Ok(Ok(tools)) => {
+            tracing::info!("connected MCP server '{name}' — {} tool(s)", tools.len());
+            McpServerState::connected(tools)
+        }
+        Ok(Err(e)) => {
+            let msg = e.to_string();
+            tracing::warn!("failed to connect MCP server '{name}': {msg}");
+            McpServerState::failed(msg)
+        }
+        Err(_) => {
+            let msg = format!(
+                "timed out after {}s",
+                McpHandler::MCP_CONNECT_TIMEOUT.as_secs()
+            );
+            tracing::warn!("MCP server '{name}' {msg}, skipping");
+            McpServerState::failed(msg)
+        }
     }
 }
 

--- a/crates/mcp/src/handler.rs
+++ b/crates/mcp/src/handler.rs
@@ -1,9 +1,9 @@
-//! Crabtalk MCP handler — initial load and read access.
+//! Crabtalk MCP handler — initial load, mutation, state, and events.
 
 use crate::McpBridge;
 use parking_lot::RwLock as SyncRwLock;
 use std::{collections::BTreeMap, sync::Arc};
-use tokio::sync::RwLock;
+use tokio::sync::{RwLock, broadcast};
 use wcore::McpServerConfig;
 
 /// Connection status for a single registered MCP server.
@@ -57,59 +57,71 @@ impl McpServerState {
     }
 }
 
+/// Lifecycle event emitted on every state transition.
+///
+/// Events go to a `tokio::sync::broadcast` channel — late subscribers
+/// see only events emitted after they subscribe. To recover prior state,
+/// callers should pair `subscribe()` with a fresh `states()` snapshot.
+#[derive(Debug, Clone)]
+pub enum McpEvent {
+    Connecting { name: String },
+    Connected { name: String, tools: Vec<String> },
+    Failed { name: String, error: String },
+    Disconnected { name: String },
+}
+
+const EVENT_CHANNEL_CAPACITY: usize = 256;
+
 /// MCP bridge owner.
 pub struct McpHandler {
     bridge: RwLock<Arc<McpBridge>>,
     /// Per-server state, keyed by server name.
     states: SyncRwLock<BTreeMap<String, McpServerState>>,
+    events_tx: broadcast::Sender<McpEvent>,
 }
 
 impl McpHandler {
-    /// Create an empty handler with no connected servers.
-    pub fn empty() -> Self {
-        Self {
-            bridge: RwLock::new(Arc::new(McpBridge::new())),
-            states: SyncRwLock::new(BTreeMap::new()),
-        }
-    }
-
-    /// Build a bridge from the given MCP server configs and discovered port files.
     /// Timeout for connecting to a single MCP server (30 seconds).
     const MCP_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
-    async fn build_bridge(
-        configs: &[McpServerConfig],
-    ) -> (McpBridge, BTreeMap<String, McpServerState>) {
-        let bridge = McpBridge::new();
-        let mut states: BTreeMap<String, McpServerState> = BTreeMap::new();
-
-        // 1. Connect servers from config.
-        for server_config in configs {
-            states.insert(server_config.name.clone(), McpServerState::connecting());
-            let state = connect_one(&bridge, server_config).await;
-            states.insert(server_config.name.clone(), state);
+    /// Create an empty handler with no connected servers.
+    pub fn empty() -> Self {
+        let (events_tx, _) = broadcast::channel(EVENT_CHANNEL_CAPACITY);
+        Self {
+            bridge: RwLock::new(Arc::new(McpBridge::new())),
+            states: SyncRwLock::new(BTreeMap::new()),
+            events_tx,
         }
-
-        // 2. Auto-discover services from port files not already registered.
-        for (name, url) in scan_port_files() {
-            if states.contains_key(&name) {
-                continue;
-            }
-            states.insert(name.clone(), McpServerState::connecting());
-            let state = connect_http(&bridge, &name, &url).await;
-            states.insert(name, state);
-        }
-
-        (bridge, states)
     }
 
     /// Load MCP servers from the given configs at startup.
     pub async fn load(configs: &[McpServerConfig]) -> Self {
-        let (bridge, states) = Self::build_bridge(configs).await;
-        Self {
-            bridge: RwLock::new(Arc::new(bridge)),
-            states: SyncRwLock::new(states),
+        let handler = Self::empty();
+        handler.connect_initial(configs).await;
+        handler
+    }
+
+    async fn connect_initial(&self, configs: &[McpServerConfig]) {
+        for cfg in configs {
+            self.upsert_server(cfg).await;
         }
+        for (name, url) in scan_port_files() {
+            if self.states.read().contains_key(&name) {
+                continue;
+            }
+            let cfg = McpServerConfig {
+                name,
+                url: Some(url),
+                ..Default::default()
+            };
+            self.upsert_server(&cfg).await;
+        }
+    }
+
+    /// Subscribe to lifecycle events. The returned receiver yields every
+    /// transition emitted while it is alive.
+    pub fn subscribe(&self) -> broadcast::Receiver<McpEvent> {
+        self.events_tx.subscribe()
     }
 
     /// List all connected servers with their tool names (live, from the bridge).
@@ -146,25 +158,54 @@ impl McpHandler {
     ///
     /// Removes any prior peer for this name from the bridge, marks the
     /// state as `Connecting`, attempts a fresh connect, and stores the
-    /// resulting state. Returns the new state.
+    /// resulting state. Emits a `Connecting` event followed by
+    /// `Connected` or `Failed`. Returns the new state.
     pub async fn upsert_server(&self, cfg: &McpServerConfig) -> McpServerState {
         let bridge = self.bridge().await;
         bridge.remove_server(&cfg.name).await;
-        self.states
-            .write()
-            .insert(cfg.name.clone(), McpServerState::connecting());
+        self.set_state(&cfg.name, McpServerState::connecting());
+        self.emit(McpEvent::Connecting {
+            name: cfg.name.clone(),
+        });
+
         let state = connect_one(&bridge, cfg).await;
-        self.states.write().insert(cfg.name.clone(), state.clone());
+        self.set_state(&cfg.name, state.clone());
+        match &state.status {
+            ServerStatus::Connected => self.emit(McpEvent::Connected {
+                name: cfg.name.clone(),
+                tools: state.tools.clone(),
+            }),
+            ServerStatus::Failed => self.emit(McpEvent::Failed {
+                name: cfg.name.clone(),
+                error: state.last_error.clone().unwrap_or_default(),
+            }),
+            ServerStatus::Connecting | ServerStatus::Disconnected => {}
+        }
         state
     }
 
     /// Disconnect and forget a single server.
     ///
-    /// Returns the prior state, if any.
+    /// Returns the prior state, if any. Emits `Disconnected` only when
+    /// an entry actually existed.
     pub async fn disconnect_server(&self, name: &str) -> Option<McpServerState> {
         let bridge = self.bridge().await;
         bridge.remove_server(name).await;
-        self.states.write().remove(name)
+        let prior = self.states.write().remove(name);
+        if prior.is_some() {
+            self.emit(McpEvent::Disconnected {
+                name: name.to_string(),
+            });
+        }
+        prior
+    }
+
+    fn set_state(&self, name: &str, state: McpServerState) {
+        self.states.write().insert(name.to_string(), state);
+    }
+
+    fn emit(&self, event: McpEvent) {
+        let _ = self.events_tx.send(event);
     }
 }
 
@@ -209,35 +250,6 @@ async fn connect_one(bridge: &McpBridge, cfg: &McpServerConfig) -> McpServerStat
                 McpHandler::MCP_CONNECT_TIMEOUT.as_secs()
             );
             tracing::warn!("MCP server '{}' {msg}, skipping", cfg.name);
-            McpServerState::failed(msg)
-        }
-    }
-}
-
-/// Attempt to connect via an already-known HTTP URL (port-file discovery).
-async fn connect_http(bridge: &McpBridge, name: &str, url: &str) -> McpServerState {
-    tracing::info!(server = %name, %url, "connecting MCP server via port file");
-    match tokio::time::timeout(
-        McpHandler::MCP_CONNECT_TIMEOUT,
-        bridge.connect_http_named(name.to_string(), url),
-    )
-    .await
-    {
-        Ok(Ok(tools)) => {
-            tracing::info!("connected MCP server '{name}' — {} tool(s)", tools.len());
-            McpServerState::connected(tools)
-        }
-        Ok(Err(e)) => {
-            let msg = e.to_string();
-            tracing::warn!("failed to connect MCP server '{name}': {msg}");
-            McpServerState::failed(msg)
-        }
-        Err(_) => {
-            let msg = format!(
-                "timed out after {}s",
-                McpHandler::MCP_CONNECT_TIMEOUT.as_secs()
-            );
-            tracing::warn!("MCP server '{name}' {msg}, skipping");
             McpServerState::failed(msg)
         }
     }

--- a/crates/mcp/src/handler.rs
+++ b/crates/mcp/src/handler.rs
@@ -141,6 +141,31 @@ impl McpHandler {
     pub fn try_bridge(&self) -> Option<Arc<McpBridge>> {
         self.bridge.try_read().ok().map(|g| Arc::clone(&*g))
     }
+
+    /// Connect (or reconnect) a single server in place.
+    ///
+    /// Removes any prior peer for this name from the bridge, marks the
+    /// state as `Connecting`, attempts a fresh connect, and stores the
+    /// resulting state. Returns the new state.
+    pub async fn upsert_server(&self, cfg: &McpServerConfig) -> McpServerState {
+        let bridge = self.bridge().await;
+        bridge.remove_server(&cfg.name).await;
+        self.states
+            .write()
+            .insert(cfg.name.clone(), McpServerState::connecting());
+        let state = connect_one(&bridge, cfg).await;
+        self.states.write().insert(cfg.name.clone(), state.clone());
+        state
+    }
+
+    /// Disconnect and forget a single server.
+    ///
+    /// Returns the prior state, if any.
+    pub async fn disconnect_server(&self, name: &str) -> Option<McpServerState> {
+        let bridge = self.bridge().await;
+        bridge.remove_server(name).await;
+        self.states.write().remove(name)
+    }
 }
 
 /// Attempt to connect a single server, applying the global timeout.

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -26,7 +26,7 @@ compile_error!("one of `native-tls` or `rustls` must be enabled");
 
 pub use {
     bridge::McpBridge,
-    handler::{McpHandler, McpServerState, ServerStatus},
+    handler::{McpEvent, McpHandler, McpServerState, ServerStatus},
 };
 
 pub mod bridge;

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -24,7 +24,10 @@ compile_error!("features `native-tls` and `rustls` are mutually exclusive");
 #[cfg(not(any(feature = "native-tls", feature = "rustls")))]
 compile_error!("one of `native-tls` or `rustls` must be enabled");
 
-pub use {bridge::McpBridge, handler::McpHandler};
+pub use {
+    bridge::McpBridge,
+    handler::{McpHandler, McpServerState, ServerStatus},
+};
 
 pub mod bridge;
 pub mod client;


### PR DESCRIPTION
## What

Closes #190.

`McpHandler` now retains per-server lifecycle state, reconnects individual servers on storage writes instead of rebuilding the daemon, and broadcasts every transition to subscribers.

- `list_mcps` reports `CONNECTING` / `CONNECTED` / `FAILED` / `DISCONNECTED` plus the actual error string. Failures no longer disappear into `tracing::warn!`.
- Adding, editing, or removing an MCP via `upsert_mcp` / `delete_mcp` mutates the live bridge in place — no `Daemon::reload()`, no torn-down agents.
- New `SubscribeMcpEvents` RPC + `crabtalkd mcp-events` CLI for streaming `Connecting` / `Connected` / `Failed` / `Disconnected` transitions.

## How

`McpHandler` keeps a `BTreeMap<String, McpServerState>` mirroring the bridge plus a `broadcast::Sender<McpEvent>`. `upsert_server` removes the prior peer, marks `Connecting`, attempts the connect with the existing 30s timeout, stores the resulting state, and emits the matching event. `disconnect_server` removes from both bridge and state map. Initial load and port-file discovery both go through `upsert_server`, so the state map is the single source of truth for the queryable view. The `mcp` hook is now registered unconditionally and computes its system prompt from `cached_list()` each call, so prompts stay in sync with live connectivity.

## Test plan

- [ ] `cargo nextest run --workspace` (passes locally — 163/163)
- [ ] Add an MCP server while the daemon is running; confirm tools become available without a reload
- [ ] Break an MCP config (bad command); confirm `list_mcps` shows `FAILED` with the error
- [ ] Run `crabtalkd mcp-events` in one terminal, mutate MCPs in another, confirm transitions stream