### PR TITLE
feat(runtime): crabllm-sdk transport, ephemeral turns, prompt caching, and edit-rewind

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,23 +531,23 @@ dependencies = [
 [[package]]
 name = "crabllm-core"
 version = "0.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4075f810aee9e09c9d475600efd75715086a95349815736cb1bf985801894e6a"
+source = "git+https://github.com/crabtalk/crabllm?branch=dev#f4599d8b560b1364d9971bd2ec68f1fbd6456cc1"
 dependencies = [
  "bytes",
+ "futures",
  "futures-core",
  "rand 0.9.2",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
 
 [[package]]
-name = "crabllm-provider"
+name = "crabllm-http"
 version = "0.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e866a21415194b3a82f38c7a1d5cc04f933f4c0e6de282c0d810273d9948d623"
+source = "git+https://github.com/crabtalk/crabllm?branch=dev#f4599d8b560b1364d9971bd2ec68f1fbd6456cc1"
 dependencies = [
  "bytes",
  "crabllm-core",
@@ -560,12 +560,19 @@ dependencies = [
  "hyper-tls",
  "hyper-util",
  "native-tls",
- "rand 0.9.2",
  "reqwest 0.13.2",
- "serde",
- "serde_json",
- "tokio",
  "tracing",
+]
+
+[[package]]
+name = "crabllm-sdk"
+version = "0.0.21"
+source = "git+https://github.com/crabtalk/crabllm?branch=dev#f4599d8b560b1364d9971bd2ec68f1fbd6456cc1"
+dependencies = [
+ "bytes",
+ "crabllm-core",
+ "crabllm-http",
+ "futures",
 ]
 
 [[package]]
@@ -577,7 +584,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crabllm-core",
- "crabllm-provider",
+ "crabllm-sdk",
  "crabtalk-core",
  "crabtalk-hooks",
  "crabtalk-mcp",
@@ -588,7 +595,6 @@ dependencies = [
  "futures-core",
  "futures-util",
  "parking_lot",
- "reqwest 0.13.2",
  "schemars 1.2.1",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,8 +530,9 @@ dependencies = [
 
 [[package]]
 name = "crabllm-core"
-version = "0.0.21"
-source = "git+https://github.com/crabtalk/crabllm?branch=dev#f4599d8b560b1364d9971bd2ec68f1fbd6456cc1"
+version = "0.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "486596f356e0db4d565bbc2c6ada0096e00dd29ad6c45d7bdfbc1e090f933be8"
 dependencies = [
  "bytes",
  "futures",
@@ -546,8 +547,9 @@ dependencies = [
 
 [[package]]
 name = "crabllm-http"
-version = "0.0.21"
-source = "git+https://github.com/crabtalk/crabllm?branch=dev#f4599d8b560b1364d9971bd2ec68f1fbd6456cc1"
+version = "0.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a83b983fc2e087818128c654ea0ecb888d6ff322532bd9e73650c636e957af9"
 dependencies = [
  "bytes",
  "crabllm-core",
@@ -566,8 +568,9 @@ dependencies = [
 
 [[package]]
 name = "crabllm-sdk"
-version = "0.0.21"
-source = "git+https://github.com/crabtalk/crabllm?branch=dev#f4599d8b560b1364d9971bd2ec68f1fbd6456cc1"
+version = "0.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516d14ce0d585e6c6fcb2c6b8bac59ec417ad8ec85057d803997a521c2790c69"
 dependencies = [
  "bytes",
  "crabllm-core",
@@ -577,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "crabtalk"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -609,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "crabtalk-bench"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "crabllm-core",
  "crabtalk",
@@ -627,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "crabtalk-cli"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -657,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "crabtalk-command"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "anyhow",
  "axum",
@@ -674,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "crabtalk-command-codegen"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -684,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "crabtalk-core"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -710,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "crabtalk-cron"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "anyhow",
  "chrono",
@@ -727,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "crabtalk-hooks"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "anyhow",
  "crabllm-core",
@@ -746,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "crabtalk-mcp"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "anyhow",
  "bytes",
@@ -767,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "crabtalk-memory"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "anyhow",
  "chrono",
@@ -777,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "crabtalk-runtime"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -795,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "crabtalk-sdk"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "anyhow",
  "crabtalk-core",
@@ -813,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "crabtalk-search"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "anyhow",
  "axum",
@@ -839,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "crabtalk-telegram"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "anyhow",
  "clap",
@@ -859,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "crabtalk-transport"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -872,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "crabtalk-wechat"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "anyhow",
  "base64",
@@ -894,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "crabtalkd"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "anyhow",
  "clap",
@@ -907,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "crabup"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ search = { path = "apps/search", package = "crabtalk-search", version = "0.0.22"
 crabtalk-cron = { path = "apps/cron", version = "0.0.22" }
 
 # crabllm
-crabllm-core = "0.0.21"
-crabllm-provider = { version = "0.0.21", default-features = false }
+crabllm-core = { git = "https://github.com/crabtalk/crabllm", branch = "dev" }
+crabllm-sdk = { git = "https://github.com/crabtalk/crabllm", branch = "dev", default-features = false }
 
 # bench
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["apps/*", "crates/*"]
 
 [workspace.package]
-version = "0.0.22"
+version = "0.0.23"
 edition = "2024"
 authors = ["clearloop <tianyi.gc@gmail.com>"]
 license = "MIT"
@@ -11,27 +11,27 @@ repository = "https://github.com/crabtalk/crabtalk"
 keywords = ["llm", "agent", "ai"]
 
 [workspace.dependencies]
-telegram = { path = "apps/telegram", package = "crabtalk-telegram", version = "0.0.22" }
-wechat = { path = "apps/wechat", package = "crabtalk-wechat", version = "0.0.22" }
-sdk = { path = "crates/sdk", package = "crabtalk-sdk", version = "0.0.22" }
-cli = { path = "apps/tui", package = "crabtalk-cli", version = "0.0.22" }
-crabtalk = { path = "crates/crabtalk", package = "crabtalk", version = "0.0.22", default-features = false }
-crabtalkd = { path = "apps/daemon", package = "crabtalkd", version = "0.0.22" }
-crabup = { path = "apps/crabup", package = "crabup", version = "0.0.22" }
-runtime = { path = "crates/runtime", package = "crabtalk-runtime", version = "0.0.22" }
-transport = { path = "crates/transport", package = "crabtalk-transport", version = "0.0.22" }
-wcore = { path = "crates/core", package = "crabtalk-core", version = "0.0.22" }
-memory = { path = "crates/memory", package = "crabtalk-memory", version = "0.0.22" }
-hooks = { path = "crates/hooks", package = "crabtalk-hooks", version = "0.0.22", default-features = false }
-mcp = { path = "crates/mcp", package = "crabtalk-mcp", version = "0.0.22", default-features = false }
-command = { path = "crates/command", package = "crabtalk-command", version = "0.0.22" }
-command-codegen = { path = "crates/command-codegen", package = "crabtalk-command-codegen", version = "0.0.22" }
-search = { path = "apps/search", package = "crabtalk-search", version = "0.0.22", default-features = false }
-crabtalk-cron = { path = "apps/cron", version = "0.0.22" }
+telegram = { path = "apps/telegram", package = "crabtalk-telegram", version = "0.0.23" }
+wechat = { path = "apps/wechat", package = "crabtalk-wechat", version = "0.0.23" }
+sdk = { path = "crates/sdk", package = "crabtalk-sdk", version = "0.0.23" }
+cli = { path = "apps/tui", package = "crabtalk-cli", version = "0.0.23" }
+crabtalk = { path = "crates/crabtalk", package = "crabtalk", version = "0.0.23", default-features = false }
+crabtalkd = { path = "apps/daemon", package = "crabtalkd", version = "0.0.23" }
+crabup = { path = "apps/crabup", package = "crabup", version = "0.0.23" }
+runtime = { path = "crates/runtime", package = "crabtalk-runtime", version = "0.0.23" }
+transport = { path = "crates/transport", package = "crabtalk-transport", version = "0.0.23" }
+wcore = { path = "crates/core", package = "crabtalk-core", version = "0.0.23" }
+memory = { path = "crates/memory", package = "crabtalk-memory", version = "0.0.23" }
+hooks = { path = "crates/hooks", package = "crabtalk-hooks", version = "0.0.23", default-features = false }
+mcp = { path = "crates/mcp", package = "crabtalk-mcp", version = "0.0.23", default-features = false }
+command = { path = "crates/command", package = "crabtalk-command", version = "0.0.23" }
+command-codegen = { path = "crates/command-codegen", package = "crabtalk-command-codegen", version = "0.0.23" }
+search = { path = "apps/search", package = "crabtalk-search", version = "0.0.23", default-features = false }
+crabtalk-cron = { path = "apps/cron", version = "0.0.23" }
 
 # crabllm
-crabllm-core = { git = "https://github.com/crabtalk/crabllm", branch = "dev" }
-crabllm-sdk = { git = "https://github.com/crabtalk/crabllm", branch = "dev", default-features = false }
+crabllm-core = "0.0.22"
+crabllm-sdk = { version = "0.0.22", default-features = false }
 
 # bench
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/apps/cron/src/runner.rs
+++ b/apps/cron/src/runner.rs
@@ -187,9 +187,7 @@ async fn fire(conn_info: &ConnectionInfo, entry: &CronEntry) {
         agent: entry.agent.clone(),
         content: format!("/{}", entry.skill),
         sender: Some(entry.sender.clone()),
-        guest: None,
-        tool_choice: None,
-        tools: vec![],
+        ..Default::default()
     };
     let mut rx = conn_info.stream(req);
     while rx.recv().await.is_some() {}

--- a/apps/telegram/src/serve.rs
+++ b/apps/telegram/src/serve.rs
@@ -212,9 +212,7 @@ async fn tg_stream(
         agent: agent.to_string(),
         content: content.to_string(),
         sender: Some(sender.to_string()),
-        guest: None,
-        tool_choice: None,
-        tools: vec![],
+        ..Default::default()
     };
     let mut event_rx = conn_info.stream(req);
     let mut acc = StreamAccumulator::new();

--- a/apps/tui/src/repl/mod.rs
+++ b/apps/tui/src/repl/mod.rs
@@ -455,9 +455,7 @@ fn start_stream(app: &mut App, content: &str) -> mpsc::UnboundedReceiver<Result<
         agent: app.agent.clone(),
         content,
         sender: Some(app.os_user.clone()),
-        guest: None,
-        tool_choice: None,
-        tools: vec![],
+        ..Default::default()
     };
     app.streaming = true;
     app.renderer.start_waiting();

--- a/apps/wechat/src/serve.rs
+++ b/apps/wechat/src/serve.rs
@@ -168,9 +168,7 @@ async fn wx_stream(
         agent: agent.to_string(),
         content: content.to_string(),
         sender: Some(sender.to_string()),
-        guest: None,
-        tool_choice: None,
-        tools: vec![],
+        ..Default::default()
     };
     let mut event_rx = conn_info.stream(req);
     let mut acc = StreamAccumulator::new();

--- a/crates/core/proto/crabtalk.proto
+++ b/crates/core/proto/crabtalk.proto
@@ -115,6 +115,14 @@ message StreamMsg {
   optional string tool_choice = 7;
   // Client-provided tool schemas — see SendMsg.tools.
   repeated ToolDef tools = 8;
+  // Run an anonymous, unpersisted turn: no conversation is created and
+  // nothing reaches session storage. Events stream back normally and are
+  // broadcast tagged `ephemeral` under `correlation_id`. Client round-trip
+  // tools are unsupported on this path.
+  bool ephemeral = 9;
+  // Caller-chosen id used to tag the ephemeral broadcast so observers can
+  // group its events. Ignored unless `ephemeral` is set.
+  optional uint64 correlation_id = 10;
 }
 
 // A tool the client can execute. The daemon advertises these schemas
@@ -535,6 +543,10 @@ message AgentEventMsg {
   string tool_output = 7;
   // - TOOL_RESULT: true when the dispatcher reported the tool as errored.
   bool tool_is_error = 8;
+  // True when this event belongs to an ephemeral (anonymous, unpersisted)
+  // turn. Consumers should surface progress but must not treat `sender`
+  // as a conversation id — there is no session behind it.
+  bool ephemeral = 9;
 }
 
 message ActiveConversationList {

--- a/crates/core/src/agent/event.rs
+++ b/crates/core/src/agent/event.rs
@@ -125,6 +125,8 @@ pub enum AgentStopReason {
     MaxIterations,
     /// No tool calls and no text response.
     NoAction,
+    /// The model hit its output token limit — the response is truncated.
+    MaxTokens,
     /// Error during execution.
     Error(String),
 }
@@ -135,6 +137,7 @@ impl std::fmt::Display for AgentStopReason {
             Self::TextResponse => write!(f, "text_response"),
             Self::MaxIterations => write!(f, "max_iterations"),
             Self::NoAction => write!(f, "no_action"),
+            Self::MaxTokens => write!(f, "max_tokens"),
             Self::Error(msg) => write!(f, "error: {msg}"),
         }
     }

--- a/crates/core/src/agent/mod.rs
+++ b/crates/core/src/agent/mod.rs
@@ -145,7 +145,10 @@ impl<P: Provider + 'static> Agent<P> {
         let system = if self.config.system_prompt.is_empty() {
             None
         } else {
-            Some(AnthropicSystem::Text(self.config.system_prompt.clone()))
+            Some(AnthropicSystem::Blocks(vec![ContentBlock::Text {
+                text: self.config.system_prompt.clone(),
+                cache_control: Some(serde_json::json!({"type": "ephemeral"})),
+            }]))
         };
 
         let tool_choice = tool_choice_override
@@ -586,9 +589,11 @@ impl<P: Provider + 'static> Agent<P> {
 }
 
 fn tools_to_anthropic(tools: &[Tool]) -> Vec<AnthropicTool> {
+    let len = tools.len();
     tools
         .iter()
-        .map(|t| AnthropicTool {
+        .enumerate()
+        .map(|(i, t)| AnthropicTool {
             name: t.function.name.clone(),
             description: t.function.description.clone(),
             input_schema: t
@@ -596,6 +601,11 @@ fn tools_to_anthropic(tools: &[Tool]) -> Vec<AnthropicTool> {
                 .parameters
                 .clone()
                 .unwrap_or(serde_json::json!({"type": "object"})),
+            cache_control: if i == len - 1 {
+                Some(serde_json::json!({"type": "ephemeral"}))
+            } else {
+                None
+            },
         })
         .collect()
 }

--- a/crates/core/src/config/llm.rs
+++ b/crates/core/src/config/llm.rs
@@ -9,8 +9,9 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct LlmConfig {
-    /// Base URL of the OpenAI-compatible endpoint, e.g.
-    /// `http://localhost:4000/v1` or `https://api.openai.com/v1`.
+    /// Gateway origin, e.g. `http://localhost:5632` or
+    /// `https://api.anthropic.com`. The SDK appends route paths
+    /// (`/v1/messages`); a trailing `/v1` is tolerated and stripped.
     #[serde(default)]
     pub base_url: String,
     /// Bearer token for the endpoint. Supports `${ENV_VAR}` interpolation

--- a/crates/core/src/model.rs
+++ b/crates/core/src/model.rs
@@ -334,11 +334,11 @@ impl<P: Provider + 'static> Model<P> {
 
     /// Send a non-streaming Anthropic messages request.
     pub async fn send(&self, request: AnthropicRequest) -> Result<AnthropicResponse> {
-        let model_label = request.model.clone();
-        self.inner
-            .anthropic_messages(&request)
-            .await
-            .map_err(|e| format_provider_error(&model_label, "send", e))
+        let model = request.model.clone();
+        self.inner.anthropic_messages(&request).await.map_err(|e| {
+            tracing::warn!(model = %model, op = "send", error = %e, "provider request failed");
+            provider_error(e)
+        })
     }
 
     /// Stream an Anthropic messages response.
@@ -349,15 +349,20 @@ impl<P: Provider + 'static> Model<P> {
         let inner = Arc::clone(&self.inner);
         let mut req = request;
         req.stream = Some(true);
-        let model_label = req.model.clone();
+        let model = req.model.clone();
         try_stream! {
             let mut stream = inner
                 .anthropic_messages_stream(&req)
                 .await
-                .map_err(|e| format_provider_error(&model_label, "stream open", e))?;
+                .map_err(|e| {
+                    tracing::warn!(model = %model, op = "stream open", error = %e, "provider request failed");
+                    provider_error(e)
+                })?;
             while let Some(chunk) = stream.next().await {
-                yield chunk
-                    .map_err(|e| format_provider_error(&model_label, "stream chunk", e))?;
+                yield chunk.map_err(|e| {
+                    tracing::warn!(model = %model, op = "stream chunk", error = %e, "provider stream failed");
+                    provider_error(e)
+                })?;
             }
         }
     }
@@ -377,15 +382,17 @@ impl<P: Provider + 'static> std::fmt::Debug for Model<P> {
     }
 }
 
-fn format_provider_error(model: &str, op: &str, e: crabllm_core::Error) -> anyhow::Error {
+/// Reduce a provider error to the clean leaf message for the client: unwrap a
+/// `Provider` body to its bare message, propagate every other variant as-is.
+fn provider_error(e: crabllm_core::Error) -> anyhow::Error {
     match e {
-        crabllm_core::Error::Provider { status, body, .. } => {
+        crabllm_core::Error::Provider { body, .. } => {
             let msg = serde_json::from_str::<ApiError>(&body)
                 .map(|api_err| api_err.error.message)
-                .unwrap_or_else(|_| truncate(&body, 200));
-            anyhow::anyhow!("model {op} failed for '{model}' (HTTP {status}): {msg}")
+                .unwrap_or(body);
+            anyhow::anyhow!(msg)
         }
-        other => anyhow::anyhow!("model {op} failed for '{model}': {other}"),
+        other => anyhow::Error::new(other),
     }
 }
 
@@ -399,13 +406,6 @@ pub fn map_stop_reason_str(r: &str) -> FinishReason {
         "max_tokens" => FinishReason::Length,
         "tool_use" => FinishReason::ToolCalls,
         other => FinishReason::Custom(other.to_string()),
-    }
-}
-
-fn truncate(s: &str, max: usize) -> String {
-    match s.char_indices().nth(max) {
-        Some((i, _)) => format!("{}...", &s[..i]),
-        None => s.to_string(),
     }
 }
 

--- a/crates/core/src/model.rs
+++ b/crates/core/src/model.rs
@@ -228,13 +228,10 @@ impl MessageBuilder {
         match event {
             AnthropicStreamEvent::ContentBlockStart {
                 index,
-                content_block,
+                content_block: crabllm_core::AnthropicContentBlock::ToolUse { id, name, .. },
             } => {
-                if let crabllm_core::AnthropicContentBlock::ToolUse { id, name, .. } = content_block
-                {
-                    self.tool_blocks
-                        .insert(*index, (id.clone(), name.clone(), String::new()));
-                }
+                self.tool_blocks
+                    .insert(*index, (id.clone(), name.clone(), String::new()));
             }
             AnthropicStreamEvent::ContentBlockDelta { index, delta } => match delta {
                 BlockDelta::Text { text } => self.content.push_str(text),

--- a/crates/core/src/model.rs
+++ b/crates/core/src/model.rs
@@ -16,7 +16,10 @@ use crabllm_core::{ApiError, Provider};
 use futures_core::Stream;
 use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
+
+/// Backstop idle-between-chunks bound for providers whose transport lacks a read timeout.
+const STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(90);
 
 // ── HistoryEntry ────────────────────────────────────────────────────
 
@@ -355,7 +358,15 @@ impl<P: Provider + 'static> Model<P> {
                     tracing::warn!(model = %model, op = "stream open", error = %e, "provider request failed");
                     provider_error(e)
                 })?;
-            while let Some(chunk) = stream.next().await {
+            loop {
+                let chunk = match tokio::time::timeout(STREAM_IDLE_TIMEOUT, stream.next()).await {
+                    Ok(Some(chunk)) => chunk,
+                    Ok(None) => break,
+                    Err(_) => {
+                        tracing::warn!(model = %model, op = "stream idle", "provider stream stalled");
+                        Err(anyhow::anyhow!("provider stream idle timeout"))?
+                    }
+                };
                 yield chunk.map_err(|e| {
                     tracing::warn!(model = %model, op = "stream chunk", error = %e, "provider stream failed");
                     provider_error(e)

--- a/crates/core/src/storage.rs
+++ b/crates/core/src/storage.rs
@@ -82,6 +82,17 @@ pub trait Storage: Send + Sync + 'static {
         archive_name: &str,
     ) -> impl Future<Output = Result<()>> + Send;
 
+    /// Rewind a session's post-compact history to its first `keep`
+    /// entries, dropping the rest — a conversation edit. The compacted
+    /// prefix (stored as the `archive` pointer, never a message row) is
+    /// preserved; only the live tail is trimmed. `keep` counts entries
+    /// after the last compaction, matching `SessionSnapshot::history`.
+    fn truncate_session_messages(
+        &self,
+        handle: &SessionHandle,
+        keep: usize,
+    ) -> impl Future<Output = Result<()>> + Send;
+
     /// Overwrite session metadata.
     fn update_session_meta(
         &self,

--- a/crates/core/src/testing/mem.rs
+++ b/crates/core/src/testing/mem.rs
@@ -169,11 +169,7 @@ impl Storage for InMemoryStorage {
         Ok(())
     }
 
-    async fn truncate_session_messages(
-        &self,
-        handle: &SessionHandle,
-        keep: usize,
-    ) -> Result<()> {
+    async fn truncate_session_messages(&self, handle: &SessionHandle, keep: usize) -> Result<()> {
         let mut sessions = self.sessions.lock();
         if let Some(state) = sessions.get_mut(handle.as_str()) {
             state.messages.truncate(keep);

--- a/crates/core/src/testing/mem.rs
+++ b/crates/core/src/testing/mem.rs
@@ -169,6 +169,19 @@ impl Storage for InMemoryStorage {
         Ok(())
     }
 
+    async fn truncate_session_messages(
+        &self,
+        handle: &SessionHandle,
+        keep: usize,
+    ) -> Result<()> {
+        let mut sessions = self.sessions.lock();
+        if let Some(state) = sessions.get_mut(handle.as_str()) {
+            state.messages.truncate(keep);
+            state.meta.message_count = state.messages.len() as u64;
+        }
+        Ok(())
+    }
+
     async fn update_session_meta(
         &self,
         handle: &SessionHandle,

--- a/crates/core/src/testing/provider.rs
+++ b/crates/core/src/testing/provider.rs
@@ -157,13 +157,13 @@ impl Provider for TestProvider {
                                 },
                             });
                         }
-                        if let Some(func) = &tc.function {
-                            if let Some(args) = &func.arguments {
-                                yield Ok(AnthropicStreamEvent::ContentBlockDelta {
-                                    index: block_index,
-                                    delta: BlockDelta::InputJson { partial_json: args.clone() },
-                                });
-                            }
+                        if let Some(func) = &tc.function
+                            && let Some(args) = &func.arguments
+                        {
+                            yield Ok(AnthropicStreamEvent::ContentBlockDelta {
+                                index: block_index,
+                                delta: BlockDelta::InputJson { partial_json: args.clone() },
+                            });
                         }
                     }
                 }

--- a/crates/crabtalk/Cargo.toml
+++ b/crates/crabtalk/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 
 [dependencies]
 crabllm-core.workspace = true
-crabllm-provider = { workspace = true, features = ["hyper"] }
+crabllm-sdk = { workspace = true, features = ["hyper"] }
 hooks = { workspace = true, default-features = false, features = ["memory", "mcp", "os", "skill"] }
 mcp = { workspace = true, default-features = false, features = ["hyper"] }
 runtime.workspace = true
@@ -29,7 +29,6 @@ async-stream.workspace = true
 futures-core.workspace = true
 futures-util.workspace = true
 parking_lot.workspace = true
-reqwest.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -42,8 +41,8 @@ ulid.workspace = true
 
 [features]
 default = ["native-tls"]
-native-tls = ["crabllm-provider/native-tls", "hooks/native-tls", "mcp/native-tls", "reqwest/native-tls"]
-rustls = ["crabllm-provider/rustls", "hooks/rustls", "mcp/rustls", "reqwest/rustls"]
+native-tls = ["crabllm-sdk/native-tls", "hooks/native-tls", "mcp/native-tls"]
+rustls = ["crabllm-sdk/rustls", "hooks/rustls", "mcp/rustls"]
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/crabtalk/src/bridge.rs
+++ b/crates/crabtalk/src/bridge.rs
@@ -51,8 +51,8 @@ impl ClientToolSet {
     }
 }
 
-impl ClientBridge {
-    pub fn new() -> Self {
+impl Default for ClientBridge {
+    fn default() -> Self {
         let mut schemas = hooks::os::schemas();
         schemas.push(sdk::tools::ask_user::schema());
         Self {
@@ -62,7 +62,9 @@ impl ClientBridge {
             pending: Mutex::new(HashMap::new()),
         }
     }
+}
 
+impl ClientBridge {
     /// Default tool schemas used when clients don't declare their own.
     pub fn default_schemas(&self) -> Vec<Tool> {
         self.defaults.schemas.clone()

--- a/crates/crabtalk/src/lib.rs
+++ b/crates/crabtalk/src/lib.rs
@@ -7,7 +7,6 @@ pub mod storage;
 pub mod system;
 
 pub use crabllm_core as llm;
-pub use crabllm_provider as llmp;
 #[cfg(unix)]
 pub use system::setup_socket;
 pub use system::{CrabTalk, CrabTalkHandle, bridge_shutdown, setup_tcp};

--- a/crates/crabtalk/src/protocol/conversation.rs
+++ b/crates/crabtalk/src/protocol/conversation.rs
@@ -52,8 +52,30 @@ impl<P: Provider + 'static> CrabTalk<P> {
             .tool_choice
             .map(|s| wcore::model::ToolChoice::from(s.as_str()));
         let req_tools = req.tools;
+        let ephemeral = req.ephemeral;
+        let correlation_id = req.correlation_id.unwrap_or(0);
         async_stream::try_stream! {
             let rt: Arc<_> = runtime.read().await.clone();
+
+            // Anonymous, unpersisted turn: no conversation, no bridge
+            // listener, no storage. Client round-trip tools are
+            // unsupported here, so only the agent's own (daemon-side)
+            // tools run.
+            if ephemeral {
+                yield StreamEvent { event: Some(stream_event::Event::Start(StreamStart { agent: agent.clone() })) };
+                let stream = rt.ephemeral_stream(&agent, &content, correlation_id, tool_choice, vec![]);
+                pin_mut!(stream);
+                while let Some(event) = stream.next().await {
+                    let is_done = matches!(event, AgentEvent::Done(_));
+                    yield agent_event_to_stream(event, &agent);
+                    if is_done { return; }
+                }
+                yield StreamEvent { event: Some(stream_event::Event::End(StreamEnd {
+                    agent: agent.clone(), error: String::new(), model: String::new(), usage: None,
+                })) };
+                return;
+            }
+
             let created_by = if sender.is_empty() { "user".into() } else { sender.clone() };
             let conversation_id = rt.get_or_create_conversation(&agent, created_by.as_str()).await?;
             // Register this conversation as having a stream listener so the
@@ -75,88 +97,31 @@ impl<P: Provider + 'static> CrabTalk<P> {
             };
             pin_mut!(stream);
             while let Some(event) = stream.next().await {
-                match event {
-                    AgentEvent::TextStart => {
-                        yield StreamEvent { event: Some(stream_event::Event::TextStart(TextStartEvent { agent: responding_agent.clone() })) };
-                    }
-                    AgentEvent::TextDelta(text) => {
-                        yield StreamEvent { event: Some(stream_event::Event::Chunk(StreamChunk { content: text })) };
-                    }
-                    AgentEvent::TextEnd => {
-                        yield StreamEvent { event: Some(stream_event::Event::TextEnd(TextEndEvent { agent: responding_agent.clone() })) };
-                    }
-                    AgentEvent::ThinkingStart => {
-                        yield StreamEvent { event: Some(stream_event::Event::ThinkingStart(ThinkingStartEvent { agent: responding_agent.clone() })) };
-                    }
-                    AgentEvent::ThinkingDelta(text) => {
-                        yield StreamEvent { event: Some(stream_event::Event::Thinking(StreamThinking { content: text })) };
-                    }
-                    AgentEvent::ThinkingEnd => {
-                        yield StreamEvent { event: Some(stream_event::Event::ThinkingEnd(ThinkingEndEvent { agent: responding_agent.clone() })) };
-                    }
-                    AgentEvent::ToolCallsBegin(calls) => {
-                        yield StreamEvent { event: Some(stream_event::Event::ToolStart(ToolStartEvent {
-                            calls: calls.into_iter().map(|c| ToolCallInfo {
-                                name: c.function.name.to_string(),
-                                arguments: String::new(),
-                            }).collect(),
-                        })) };
-                    }
-                    AgentEvent::ToolCallsStart(calls) => {
-                        let forwards: Vec<ToolCallForwardEvent> = calls
-                            .iter()
-                            .filter(|c| bridge.is_client_tool(conversation_id, &c.function.name))
-                            .map(|c| ToolCallForwardEvent {
-                                call_id: c.id.to_string(),
-                                name: c.function.name.to_string(),
-                                arguments: c.function.arguments.clone(),
-                                conversation_id,
-                            })
-                            .collect();
-
-                        yield StreamEvent { event: Some(stream_event::Event::ToolStart(ToolStartEvent {
-                            calls: calls.into_iter().map(|c| ToolCallInfo {
-                                name: c.function.name.to_string(),
-                                arguments: c.function.arguments,
-                            }).collect(),
-                        })) };
-
-                        for fwd in forwards {
-                            yield StreamEvent { event: Some(stream_event::Event::ToolCallForward(fwd)) };
-                        }
-                    }
-                    AgentEvent::ToolResult { call_id, output, duration_ms } => {
-                        let is_error = output.is_err();
-                        let output = match output { Ok(s) | Err(s) => s };
-                        yield StreamEvent { event: Some(stream_event::Event::ToolResult(ToolResultEvent { call_id: call_id.to_string(), output, duration_ms, is_error })) };
-                    }
-                    AgentEvent::ToolCallsComplete => {
-                        yield StreamEvent { event: Some(stream_event::Event::ToolsComplete(ToolsCompleteEvent {})) };
-                    }
-                    AgentEvent::ContextUsage { ref usage } => {
-                        yield StreamEvent { event: Some(stream_event::Event::ContextUsage(ContextUsageEvent { usage: Some(usage_to_proto(usage)) })) };
-                    }
-                    AgentEvent::UserSteered { ref content } => {
-                        yield StreamEvent { event: Some(stream_event::Event::UserSteered(UserSteeredEvent { content: content.clone() })) };
-                    }
-                    AgentEvent::Done(resp) => {
-                        let error = if let wcore::AgentStopReason::Error(ref e) = resp.stop_reason {
-                            e.clone()
-                        } else {
-                            String::new()
-                        };
-                        yield StreamEvent { event: Some(stream_event::Event::End(StreamEnd {
-                            agent: responding_agent.clone(),
-                            error,
-                            model: resp.model,
-                            usage: Some(sum_usage(&resp.steps)),
-                        })) };
-                        return;
-                    }
+                // Client-tool forwards only exist on the persisted path,
+                // where a bridge listener can carry the reply back.
+                let forwards: Vec<ToolCallForwardEvent> = if let AgentEvent::ToolCallsStart(ref calls) = event {
+                    calls
+                        .iter()
+                        .filter(|c| bridge.is_client_tool(conversation_id, &c.function.name))
+                        .map(|c| ToolCallForwardEvent {
+                            call_id: c.id.to_string(),
+                            name: c.function.name.to_string(),
+                            arguments: c.function.arguments.clone(),
+                            conversation_id,
+                        })
+                        .collect()
+                } else {
+                    Vec::new()
+                };
+                let is_done = matches!(event, AgentEvent::Done(_));
+                yield agent_event_to_stream(event, &responding_agent);
+                for fwd in forwards {
+                    yield StreamEvent { event: Some(stream_event::Event::ToolCallForward(fwd)) };
                 }
+                if is_done { return; }
             }
             yield StreamEvent { event: Some(stream_event::Event::End(StreamEnd {
-                agent: responding_agent.clone(),
+                agent: responding_agent,
                 error: String::new(),
                 model: String::new(),
                 usage: None,
@@ -211,6 +176,82 @@ impl Drop for ListenerGuard {
     fn drop(&mut self) {
         self.bridge.unregister_listener(self.conv_id);
     }
+}
+
+/// Map one agent loop event to its wire `StreamEvent`. Shared by the
+/// persisted and ephemeral stream paths; client-tool forwarding (which
+/// only the persisted path can route) is handled by the caller.
+fn agent_event_to_stream(event: AgentEvent, responding_agent: &str) -> StreamEvent {
+    use stream_event::Event;
+    let event = match event {
+        AgentEvent::TextStart => Event::TextStart(TextStartEvent {
+            agent: responding_agent.to_string(),
+        }),
+        AgentEvent::TextDelta(text) => Event::Chunk(StreamChunk { content: text }),
+        AgentEvent::TextEnd => Event::TextEnd(TextEndEvent {
+            agent: responding_agent.to_string(),
+        }),
+        AgentEvent::ThinkingStart => Event::ThinkingStart(ThinkingStartEvent {
+            agent: responding_agent.to_string(),
+        }),
+        AgentEvent::ThinkingDelta(text) => Event::Thinking(StreamThinking { content: text }),
+        AgentEvent::ThinkingEnd => Event::ThinkingEnd(ThinkingEndEvent {
+            agent: responding_agent.to_string(),
+        }),
+        AgentEvent::ToolCallsBegin(calls) => Event::ToolStart(ToolStartEvent {
+            calls: calls
+                .into_iter()
+                .map(|c| ToolCallInfo {
+                    name: c.function.name.to_string(),
+                    arguments: String::new(),
+                })
+                .collect(),
+        }),
+        AgentEvent::ToolCallsStart(calls) => Event::ToolStart(ToolStartEvent {
+            calls: calls
+                .into_iter()
+                .map(|c| ToolCallInfo {
+                    name: c.function.name.to_string(),
+                    arguments: c.function.arguments,
+                })
+                .collect(),
+        }),
+        AgentEvent::ToolResult {
+            call_id,
+            output,
+            duration_ms,
+        } => {
+            let is_error = output.is_err();
+            let output = match output {
+                Ok(s) | Err(s) => s,
+            };
+            Event::ToolResult(ToolResultEvent {
+                call_id: call_id.to_string(),
+                output,
+                duration_ms,
+                is_error,
+            })
+        }
+        AgentEvent::ToolCallsComplete => Event::ToolsComplete(ToolsCompleteEvent {}),
+        AgentEvent::ContextUsage { usage } => Event::ContextUsage(ContextUsageEvent {
+            usage: Some(usage_to_proto(&usage)),
+        }),
+        AgentEvent::UserSteered { content } => Event::UserSteered(UserSteeredEvent { content }),
+        AgentEvent::Done(resp) => {
+            let error = if let wcore::AgentStopReason::Error(ref e) = resp.stop_reason {
+                e.clone()
+            } else {
+                String::new()
+            };
+            Event::End(StreamEnd {
+                agent: responding_agent.to_string(),
+                error,
+                model: resp.model,
+                usage: Some(sum_usage(&resp.steps)),
+            })
+        }
+    };
+    StreamEvent { event: Some(event) }
 }
 
 pub(super) fn sum_usage(steps: &[wcore::AgentStep]) -> TokenUsage {

--- a/crates/crabtalk/src/storage/fs/mod.rs
+++ b/crates/crabtalk/src/storage/fs/mod.rs
@@ -168,6 +168,10 @@ impl Storage for FsStorage {
         sessions::append_session_compact(self, handle, archive_name).await
     }
 
+    async fn truncate_session_messages(&self, handle: &SessionHandle, keep: usize) -> Result<()> {
+        sessions::truncate_session_messages(self, handle, keep).await
+    }
+
     async fn update_session_meta(
         &self,
         handle: &SessionHandle,

--- a/crates/crabtalk/src/storage/fs/sessions.rs
+++ b/crates/crabtalk/src/storage/fs/sessions.rs
@@ -276,6 +276,49 @@ pub(super) async fn append_session_compact(
     write_step(storage, handle.as_str(), line).await
 }
 
+pub(super) async fn truncate_session_messages(
+    storage: &FsStorage,
+    handle: &SessionHandle,
+    keep: usize,
+) -> Result<()> {
+    let Some(snapshot) = load_session(storage, handle).await? else {
+        return Ok(());
+    };
+    let kept: Vec<HistoryEntry> = snapshot.history.into_iter().take(keep).collect();
+    // Wipe the step log, then re-lay the compacted boundary (if any) followed
+    // by the kept entries. Trace events for the dropped turns go with them.
+    // `next_step`'s counter keeps climbing, so new steps sort after the void.
+    let dir = session_dir(storage, handle.as_str());
+    let mut rd = fs::read_dir(&dir).await?;
+    while let Some(entry) = rd.next_entry().await? {
+        if entry
+            .file_name()
+            .to_str()
+            .is_some_and(|n| n.starts_with("step-"))
+        {
+            fs::remove_file(entry.path()).await?;
+        }
+    }
+    if let Some(archive_name) = snapshot.archive {
+        write_step(
+            storage,
+            handle.as_str(),
+            StepLine::Compact {
+                archive_name,
+                archived_at: chrono::Utc::now().to_rfc3339(),
+            },
+        )
+        .await?;
+    }
+    for entry in &kept {
+        write_step(storage, handle.as_str(), StepLine::Entry(entry.clone())).await?;
+    }
+    let mut meta = snapshot.meta;
+    meta.message_count = kept.len() as u64;
+    update_session_meta(storage, handle, &meta).await?;
+    Ok(())
+}
+
 pub(super) async fn update_session_meta(
     storage: &FsStorage,
     handle: &SessionHandle,

--- a/crates/crabtalk/src/system/builder.rs
+++ b/crates/crabtalk/src/system/builder.rs
@@ -1,7 +1,6 @@
 //! CrabTalk construction and lifecycle methods.
 
 use crate::llm::Provider;
-use crate::llmp::{ProviderRegistry, RemoteProvider};
 use crate::{
     CrabTalk,
     bridge::ClientBridge,
@@ -22,7 +21,7 @@ use std::{
 use tokio::sync::{RwLock, broadcast};
 use wcore::{LlmConfig, ResolvedDirs, model::Model, resolve_dirs, storage::Storage};
 
-pub type DefaultProvider = crate::llm::Retrying<ProviderRegistry<RemoteProvider>>;
+pub type DefaultProvider = crabllm_sdk::Client;
 
 /// Build the LLM `Model<P>` given the config and the list of models
 /// advertised by the endpoint (fetched from `/v1/models` at startup).
@@ -302,30 +301,13 @@ impl<P: Provider + 'static> CrabTalk<P> {
 
 fn build_providers(config: &wcore::Config, models: &[String]) -> Result<Model<DefaultProvider>> {
     let llm = &config.llm;
-    let provider_cfg = crate::llm::ProviderConfig {
-        kind: crate::llm::ProviderKind::Anthropic,
-        base_url: (!llm.base_url.is_empty()).then(|| llm.base_url.clone()),
-        api_key: (!llm.api_key.is_empty()).then(|| llm.api_key.clone()),
-        models: models.to_vec(),
-        ..Default::default()
-    };
-
-    let mut providers = std::collections::HashMap::new();
-    providers.insert("llm".to_owned(), provider_cfg);
-
-    let registry = ProviderRegistry::from_provider_configs(
-        &providers,
-        &std::collections::HashMap::new(),
-        |r| r,
-    )?;
-    let retrying = crate::llm::Retrying::new(registry);
-
+    let client = crabllm_sdk::Client::new(llm.base_url.clone(), llm.api_key.clone());
     tracing::info!(
         "llm endpoint registered — {} models from {}",
         models.len(),
         llm.base_url
     );
-    Ok(Model::new(retrying))
+    Ok(Model::new(client))
 }
 
 /// Fetch `/v1/models` from the configured LLM endpoint. Returns an empty
@@ -336,29 +318,12 @@ async fn fetch_models(llm: &LlmConfig) -> Vec<String> {
         tracing::warn!("no llm.base_url configured in config.toml — model list is empty");
         return Vec::new();
     }
-    let url = format!("{}/models", llm.base_url.trim_end_matches('/'));
-    let mut req = reqwest::Client::new().get(&url);
-    if !llm.api_key.is_empty() {
-        req = req.bearer_auth(&llm.api_key);
-    }
-    match fetch_models_inner(req).await {
-        Ok(models) => models,
+    let client = crabllm_sdk::Client::new(llm.base_url.clone(), llm.api_key.clone());
+    match client.models().await {
+        Ok(list) => list.data.into_iter().map(|m| m.id).collect(),
         Err(e) => {
-            tracing::warn!("failed to fetch {url}: {e}");
+            tracing::warn!("failed to list models from {}: {e}", llm.base_url);
             Vec::new()
         }
     }
-}
-
-async fn fetch_models_inner(req: reqwest::RequestBuilder) -> Result<Vec<String>> {
-    let body: serde_json::Value = req.send().await?.error_for_status()?.json().await?;
-    Ok(body
-        .get("data")
-        .and_then(|d| d.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.get("id").and_then(|i| i.as_str()).map(String::from))
-                .collect()
-        })
-        .unwrap_or_default())
 }

--- a/crates/crabtalk/src/system/builder.rs
+++ b/crates/crabtalk/src/system/builder.rs
@@ -181,7 +181,7 @@ impl<P: Provider + 'static> CrabTalk<P> {
 
         let model = build_provider(config, &models)?;
         let mcp_handler: Arc<McpHandler> = Arc::new(McpHandler::empty());
-        let bridge = Arc::new(ClientBridge::new());
+        let bridge = Arc::new(ClientBridge::default());
         let shared_memory = Self::register_hooks(
             &mut hooks,
             storage.clone(),

--- a/crates/crabtalk/src/system/host.rs
+++ b/crates/crabtalk/src/system/host.rs
@@ -31,7 +31,13 @@ impl Env for SystemEnv {
         &self.hook
     }
 
-    fn on_agent_event(&self, agent: &str, conversation_id: u64, event: &AgentEvent) {
+    fn on_agent_event(
+        &self,
+        agent: &str,
+        conversation_id: u64,
+        ephemeral: bool,
+        event: &AgentEvent,
+    ) {
         struct Payload {
             kind: AgentEventKind,
             content: String,
@@ -137,6 +143,7 @@ impl Env for SystemEnv {
             tool_calls: p.tool_calls,
             tool_output: p.tool_output,
             tool_is_error: p.tool_is_error,
+            ephemeral,
         });
     }
 

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -16,7 +16,7 @@ anyhow.workspace = true
 parking_lot.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-tokio = { workspace = true, features = ["process", "io-util"] }
+tokio = { workspace = true, features = ["process", "io-util", "time"] }
 tracing.workspace = true
 
 # HTTP backends — pick exactly one of `reqwest` or `hyper`.

--- a/crates/mcp/src/client/http/hyper.rs
+++ b/crates/mcp/src/client/http/hyper.rs
@@ -7,10 +7,13 @@ use http::Request;
 use http_body_util::{BodyExt, Full, Limited};
 use hyper_util::client::legacy::{Client, connect::HttpConnector};
 use hyper_util::rt::TokioExecutor;
+use std::time::Duration;
 
 /// Cap on MCP response bodies — protects against runaway servers. MCP
 /// tool results are short; 16 MiB is generous.
 const MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
+/// Total round-trip bound per call; without it a hung server stalls the tool call forever.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[cfg(feature = "native-tls")]
 type Connector = hyper_tls::HttpsConnector<HttpConnector>;
@@ -66,29 +69,31 @@ impl HttpTransport {
         }
         let req = builder.body(Full::new(Bytes::from(body)))?;
 
-        let resp = self
-            .client
-            .request(req)
+        let client = &self.client;
+        let (status, session_id, content_type, bytes) =
+            tokio::time::timeout(REQUEST_TIMEOUT, async move {
+                let resp = client.request(req).await.context("HTTP request failed")?;
+                let status = resp.status();
+                let session_id = resp
+                    .headers()
+                    .get("mcp-session-id")
+                    .and_then(|v| v.to_str().ok())
+                    .map(String::from);
+                let content_type = resp
+                    .headers()
+                    .get("content-type")
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or("")
+                    .to_string();
+                let bytes = Limited::new(resp.into_body(), MAX_BODY_BYTES)
+                    .collect()
+                    .await
+                    .map_err(|e| anyhow::anyhow!("failed to read response body: {e}"))?
+                    .to_bytes();
+                Ok::<_, anyhow::Error>((status, session_id, content_type, bytes))
+            })
             .await
-            .context("HTTP request failed")?;
-        let status = resp.status();
-        let session_id = resp
-            .headers()
-            .get("mcp-session-id")
-            .and_then(|v| v.to_str().ok())
-            .map(String::from);
-        let content_type = resp
-            .headers()
-            .get("content-type")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("")
-            .to_string();
-
-        let bytes = Limited::new(resp.into_body(), MAX_BODY_BYTES)
-            .collect()
-            .await
-            .map_err(|e| anyhow::anyhow!("failed to read response body: {e}"))?
-            .to_bytes();
+            .context("HTTP request timed out")??;
         let body = std::str::from_utf8(&bytes).context("response body not UTF-8")?;
 
         if !status.is_success() {
@@ -119,9 +124,9 @@ impl HttpTransport {
             builder = builder.header("mcp-session-id", sid);
         }
         let req = builder.body(Full::new(Bytes::from(body)))?;
-        self.client
-            .request(req)
+        tokio::time::timeout(REQUEST_TIMEOUT, self.client.request(req))
             .await
+            .context("HTTP notify timed out")?
             .context("HTTP notify failed")?;
         Ok(())
     }

--- a/crates/mcp/src/client/http/reqwest.rs
+++ b/crates/mcp/src/client/http/reqwest.rs
@@ -2,6 +2,10 @@
 
 use crate::client::sse;
 use anyhow::{Context, Result, bail};
+use std::time::Duration;
+
+/// Total round-trip bound per call; without it a hung server stalls the tool call forever.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub struct HttpTransport {
     client: reqwest::Client,
@@ -13,7 +17,10 @@ pub struct HttpTransport {
 impl HttpTransport {
     pub fn new(url: &str, auth: Option<String>) -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .timeout(REQUEST_TIMEOUT)
+                .build()
+                .expect("crabtalk-mcp: failed to build reqwest client"),
             url: url.to_string(),
             auth,
             session_id: None,

--- a/crates/runtime/src/engine/conversation.rs
+++ b/crates/runtime/src/engine/conversation.rs
@@ -6,7 +6,10 @@ use anyhow::{Result, bail};
 use memory::{EntryKind, Op};
 use std::sync::{Arc, atomic::Ordering};
 use tokio::sync::Mutex;
-use wcore::{model::HistoryEntry, storage::Storage};
+use wcore::{
+    model::{HistoryEntry, Role},
+    storage::Storage,
+};
 
 impl<C: Config> Runtime<C> {
     pub(super) fn new_slot(id: u64, agent: &str, created_by: &str) -> ConvSlot {
@@ -253,6 +256,60 @@ impl<C: Config> Runtime<C> {
             .update_session_meta(&handle, &conversation.meta(&agent_name, &created_by))
             .await;
         Some(summary)
+    }
+
+    /// Rewind `agent`/`sender`'s conversation by `turns` user turns.
+    pub async fn truncate_conversation(
+        &self,
+        agent: &str,
+        sender: &str,
+        turns: usize,
+    ) -> Result<usize> {
+        let id = self.require_conversation_id(agent, sender).await?;
+        self.truncate(id, turns).await
+    }
+
+    /// Rewind a conversation by dropping its last `turns` user turns — the
+    /// user message that opens each turn and everything after it — from both
+    /// the live history and storage. Used to re-run an edited message: drop
+    /// the turn, then re-send the new text. Never rewinds past a compacted
+    /// prefix. Returns the new history length.
+    pub async fn truncate(&self, conversation_id: u64, turns: usize) -> Result<usize> {
+        let conversation_mutex = self
+            .conversation(conversation_id)
+            .await
+            .ok_or_else(|| anyhow::anyhow!("conversation {conversation_id} not found"))?;
+        let mut conversation = conversation_mutex.lock().await;
+        // Boundary = the index of the `turns`-th user entry counting from the
+        // end; everything before it survives.
+        let mut seen = 0;
+        let mut boundary = None;
+        for (i, entry) in conversation.history.iter().enumerate().rev() {
+            if matches!(entry.role(), Role::User) && !entry.auto_injected {
+                seen += 1;
+                if seen == turns {
+                    boundary = Some(i);
+                    break;
+                }
+            }
+        }
+        let Some(boundary) = boundary else {
+            return Ok(conversation.history.len());
+        };
+        conversation.history.truncate(boundary);
+        if let Some(handle) = conversation.handle.clone() {
+            // The storage layer's history excludes the archive prefix, so
+            // `keep` counts the post-compact, non-injected survivors.
+            let archive_offset = usize::from(conversation.summary.is_some());
+            let keep = conversation.history[archive_offset..]
+                .iter()
+                .filter(|e| !e.auto_injected)
+                .count();
+            self.storage()
+                .truncate_session_messages(&handle, keep)
+                .await?;
+        }
+        Ok(conversation.history.len())
     }
 
     pub async fn transfer_to<C2: Config>(&self, dest: &mut Runtime<C2>) {

--- a/crates/runtime/src/engine/conversation.rs
+++ b/crates/runtime/src/engine/conversation.rs
@@ -265,7 +265,11 @@ impl<C: Config> Runtime<C> {
         sender: &str,
         turns: usize,
     ) -> Result<usize> {
-        let id = self.require_conversation_id(agent, sender).await?;
+        // Lazy-load from storage (like the send path) rather than requiring a
+        // live conversation: after a reload the transcript is restored but the
+        // runtime hasn't materialized this conversation yet, and edit-rewind
+        // must still find the persisted turn to drop.
+        let id = self.get_or_create_conversation(agent, sender).await?;
         self.truncate(id, turns).await
     }
 

--- a/crates/runtime/src/engine/execution.rs
+++ b/crates/runtime/src/engine/execution.rs
@@ -268,6 +268,7 @@ impl<C: Config> Runtime<C> {
                 use crabllm_core::{AnthropicStreamEvent, BlockDelta};
 
                 let mut stream = std::pin::pin!(self.model.stream(request));
+                let mut saw_stop = false;
                 while let Some(result) = stream.next().await {
                     match result {
                         Ok(AnthropicStreamEvent::ContentBlockDelta { delta, .. }) => {
@@ -283,8 +284,18 @@ impl<C: Config> Runtime<C> {
                                 BlockDelta::InputJson { .. } => {}
                             }
                         }
+                        Ok(AnthropicStreamEvent::MessageDelta { delta, .. }) => {
+                            saw_stop |= delta.stop_reason.is_some();
+                        }
+                        Ok(AnthropicStreamEvent::MessageStop) => {
+                            saw_stop = true;
+                        }
                         Ok(_) => {}
                         Err(e) => {
+                            // A connection close after the turn completed isn't a failure.
+                            if saw_stop {
+                                break;
+                            }
                             yield AgentEvent::Done(AgentResponse {
                                 final_response: None,
                                 iterations: 1,

--- a/crates/runtime/src/engine/execution.rs
+++ b/crates/runtime/src/engine/execution.rs
@@ -284,11 +284,16 @@ impl<C: Config> Runtime<C> {
                 })
                 .collect();
 
-            let max_tokens = DEFAULT_MAX_TOKENS;
+            // For extended thinking `max_tokens` is the TOTAL budget (reasoning +
+            // visible output), so the reasoning budget sits ON TOP of the response
+            // allowance. Budgeting thinking at `max_tokens - 1` left ~1 token for
+            // the answer and truncated it mid-word.
+            const THINKING_BUDGET: u32 = 4096;
             let thinking = guest_agent.config.thinking.then(|| ThinkingConfig {
                 kind: "enabled".to_string(),
-                budget_tokens: Some(max_tokens.saturating_sub(1)),
+                budget_tokens: Some(THINKING_BUDGET),
             });
+            let max_tokens = DEFAULT_MAX_TOKENS + thinking.as_ref().map_or(0, |_| THINKING_BUDGET);
 
             let request = AnthropicRequest {
                 model: model_name.clone(),
@@ -306,6 +311,7 @@ impl<C: Config> Runtime<C> {
 
             let mut response_text = String::new();
             let mut reasoning = String::new();
+            let mut truncated = false;
             {
                 use crabllm_core::{AnthropicStreamEvent, BlockDelta};
 
@@ -328,6 +334,7 @@ impl<C: Config> Runtime<C> {
                         }
                         Ok(AnthropicStreamEvent::MessageDelta { delta, .. }) => {
                             saw_stop |= delta.stop_reason.is_some();
+                            truncated |= delta.stop_reason.as_deref() == Some("max_tokens");
                         }
                         Ok(AnthropicStreamEvent::MessageStop) => {
                             saw_stop = true;
@@ -372,7 +379,11 @@ impl<C: Config> Runtime<C> {
             yield AgentEvent::Done(AgentResponse {
                 final_response: Some(response_text),
                 iterations: 1,
-                stop_reason: AgentStopReason::TextResponse,
+                stop_reason: if truncated {
+                    AgentStopReason::MaxTokens
+                } else {
+                    AgentStopReason::TextResponse
+                },
                 steps: vec![],
                 model: model_name,
             });

--- a/crates/runtime/src/engine/execution.rs
+++ b/crates/runtime/src/engine/execution.rs
@@ -85,7 +85,7 @@ impl<C: Config> Runtime<C> {
                 .hook()
                 .on_event(&agent_name, conversation_id, &event);
             self.env
-                .on_agent_event(&agent_name, conversation_id, &event);
+                .on_agent_event(&agent_name, conversation_id, false, &event);
             if let Some(line) = wcore::EventLine::from_agent_event(&event) {
                 event_trace.push(line);
             }
@@ -141,7 +141,7 @@ impl<C: Config> Runtime<C> {
                 let mut event_stream = std::pin::pin!(agent.run_stream(&mut conversation.history, Some(conversation_id), Some(steer_rx), tool_choice));
                 while let Some(event) = event_stream.next().await {
                     self.env.hook().on_event(&agent_name, conversation_id, &event);
-                    self.env.on_agent_event(&agent_name, conversation_id, &event);
+                    self.env.on_agent_event(&agent_name, conversation_id, false, &event);
                     if let Some(line) = wcore::EventLine::from_agent_event(&event) {
                         event_trace.push(line);
                     }
@@ -162,6 +162,48 @@ impl<C: Config> Runtime<C> {
             )
             .await;
             if let Some(event) = done_event {
+                yield event;
+            }
+        }
+    }
+
+    /// Run a single agent turn with no conversation and no persistence.
+    ///
+    /// Unlike [`Self::stream_to`], this acquires no slot, writes nothing
+    /// to storage or the search index, and never fires the subscription
+    /// hook — so there is nothing to clean up afterward. The full agent
+    /// loop still runs (multi-step tool calls included), and each event is
+    /// broadcast via [`Env::on_agent_event`] tagged `ephemeral` with the
+    /// caller-supplied `correlation_id`, so observers can show live
+    /// progress without mistaking it for a chat session.
+    ///
+    /// The loop's tool dispatch runs with no conversation id, so
+    /// `extra_tools` must be self-contained daemon-side tools — client
+    /// round-trip tools have no listener to reply through.
+    pub fn ephemeral_stream<'a>(
+        &'a self,
+        agent_name: &'a str,
+        content: &'a str,
+        correlation_id: u64,
+        tool_choice: Option<ToolChoice>,
+        extra_tools: Vec<crabllm_core::Tool>,
+    ) -> impl Stream<Item = AgentEvent> + 'a {
+        let content = content.to_owned();
+        stream! {
+            let Some(mut agent) = self.resolve_agent(agent_name).await else {
+                yield AgentEvent::Done(AgentResponse::error(
+                    format!("agent '{agent_name}' not registered"),
+                ));
+                return;
+            };
+            agent.extend_tools(extra_tools);
+
+            let mut history = vec![HistoryEntry::user(&content)];
+            let mut event_stream =
+                std::pin::pin!(agent.run_stream(&mut history, None, None, tool_choice));
+            while let Some(event) = event_stream.next().await {
+                self.env
+                    .on_agent_event(agent_name, correlation_id, true, &event);
                 yield event;
             }
         }

--- a/crates/runtime/src/env.rs
+++ b/crates/runtime/src/env.rs
@@ -21,7 +21,18 @@ pub trait Env: Send + Sync + 'static {
     fn hook(&self) -> &Self::Hook;
 
     /// Called when an agent event occurs. Default: no-op.
-    fn on_agent_event(&self, _agent: &str, _conversation_id: u64, _event: &AgentEvent) {}
+    ///
+    /// `ephemeral` marks events from an anonymous, unpersisted turn —
+    /// `conversation_id` is then a caller-supplied correlation id, not a
+    /// real session.
+    fn on_agent_event(
+        &self,
+        _agent: &str,
+        _conversation_id: u64,
+        _ephemeral: bool,
+        _event: &AgentEvent,
+    ) {
+    }
 
     /// Subscribe to agent events. Returns `None` if event broadcasting
     /// is not supported.

--- a/crates/sdk/src/conn.rs
+++ b/crates/sdk/src/conn.rs
@@ -98,6 +98,29 @@ impl ConnectionInfo {
         rx
     }
 
+    /// Run an anonymous, unpersisted agent turn and return a receiver of
+    /// stream events. No conversation is created and nothing reaches
+    /// session storage; events are also broadcast (tagged `ephemeral`)
+    /// under `correlation_id` so observers can group them. Client
+    /// round-trip tools are unsupported on this path — only the agent's
+    /// own daemon-side tools run.
+    pub fn ephemeral_stream(
+        &self,
+        agent: String,
+        content: String,
+        correlation_id: u64,
+        tool_choice: Option<String>,
+    ) -> mpsc::UnboundedReceiver<Result<stream_event::Event>> {
+        self.stream(StreamMsg {
+            agent,
+            content,
+            ephemeral: true,
+            correlation_id: Some(correlation_id),
+            tool_choice,
+            ..Default::default()
+        })
+    }
+
     /// Open a fresh connection, deliver a client-side tool result for the
     /// pending forwarded call keyed by `(conversation_id, call_id)`, and
     /// close.


### PR DESCRIPTION
## What

Adopts `crabllm-sdk` as the LLM transport and builds two capabilities on top of it: prompt-caching breakpoints and an anonymous, unpersisted agent turn. Also lands edit-rewind (conversation truncation) and a set of robustness fixes — stream and tool-call timeouts, and reasoning-budget accounting.

## How

- **crabllm-sdk transport** — replaces the `crabllm-provider` registry/retry stack with `crabllm_sdk::Client`. `llm.base_url` is now a gateway origin (the SDK appends `/v1/messages` and tolerates a trailing `/v1`); model listing and provider-error unwrapping go through the SDK. Pinned to crates.io `0.0.22`.
- **Prompt caching** — the system prompt and the final tool schema carry an `ephemeral` `cache_control` breakpoint so both blocks are cached across requests.
- **Ephemeral turns** — `Runtime::ephemeral_stream` / `ConnectionInfo::ephemeral_stream` run a full agent loop with no conversation, storage, or bridge listener. Events stream back tagged `ephemeral` under a caller-supplied `correlation_id`; only daemon-side tools run. `StreamMsg`/`AgentEventMsg` gain the corresponding fields, and the persisted/ephemeral paths now share one `agent_event_to_stream` mapper.
- **Stream fix** — a connection close *after* the turn's stop reason is no longer surfaced as an error.
- **Edit-rewind** — `truncate_conversation` rewinds history to the *n*-th prior user turn so a client can re-send an edited message; the conversation is lazy-loaded on truncate so a rewind survives a daemon reload.
- **Timeouts** — provider stream reads get an idle-timeout backstop; MCP HTTP tool calls are bounded by a request timeout.
- **Reasoning budget** — thinking tokens are budgeted on top of the output cap rather than carved out of it, and max-tokens truncation is surfaced as a distinct stop reason.

Workspace bumped to `0.0.23`.
