### PR TITLE
feat(code): crab, an in-process coding agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,6 +811,7 @@ version = "0.0.24"
 dependencies = [
  "anyhow",
  "chrono",
+ "crabllm-core",
  "crabtalk",
  "crabtalk-proto",
  "crabtalk-store",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,6 +768,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crabtalk-code"
+version = "0.0.24"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "crabtalk",
+ "crabtalk-proto",
+ "crabtalk-store",
+ "crabup",
+ "futures-util",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "crabtalk-crabdb"
 version = "0.0.24"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,7 +127,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -212,7 +212,7 @@ checksum = "25b02b51a3197f215af8ab86a8f2aba7ad59eaeb7e338761be48f7142ba6a923"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -349,7 +349,7 @@ checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -424,6 +424,12 @@ dependencies = [
  "serde_plain",
  "tracing",
 ]
+
+[[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "castaway"
@@ -508,7 +514,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -553,6 +559,20 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "compact_str"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
@@ -564,6 +584,24 @@ dependencies = [
  "ryu",
  "serde",
  "static_assertions",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "coolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "980c2afde4af43d6a05c5be738f9eae595cff86dce1f38f88b95058a98c027f3"
+dependencies = [
+ "crossterm 0.29.0",
 ]
 
 [[package]]
@@ -777,9 +815,13 @@ dependencies = [
  "crabtalk-proto",
  "crabtalk-store",
  "crabup",
+ "crossterm 0.28.1",
  "futures-util",
+ "heck",
+ "ratatui",
  "serde",
  "serde_json",
+ "termimad",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -875,7 +917,7 @@ name = "crabtalk-search"
 version = "0.0.24"
 dependencies = [
  "base64 0.22.1",
- "lru",
+ "lru 0.14.0",
  "percent-encoding",
  "rand 0.9.2",
  "reqwest",
@@ -1158,6 +1200,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "crokey"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "074bc31bff1084f74e5a145ad5f6ac74469fa312159faa5144f0b1c4506b8d80"
+dependencies = [
+ "crokey-proc_macros",
+ "crossterm 0.29.0",
+ "once_cell",
+ "serde",
+ "strict",
+]
+
+[[package]]
+name = "crokey-proc_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b88c4ff2d5717616c3bb4a31d06b0b241ed811c7c0c41d077d77631bee7caad0"
+dependencies = [
+ "crossterm 0.29.0",
+ "proc-macro2",
+ "quote",
+ "strict",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1177,10 +1267,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "futures-core",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "derive_more 2.1.1",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix 1.1.4",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -1218,7 +1361,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1227,8 +1370,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
+dependencies = [
+ "darling_core 0.24.1",
+ "darling_macro 0.24.1",
 ]
 
 [[package]]
@@ -1242,7 +1395,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1251,9 +1417,20 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
+dependencies = [
+ "darling_core 0.24.1",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1280,10 +1457,10 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1293,7 +1470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1304,7 +1481,29 @@ checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1346,7 +1545,16 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -1443,7 +1651,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1633,7 +1841,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1809,7 +2017,7 @@ version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -2273,6 +2481,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf84e73fa6f27f299dec58e13223cf70db80da872eb921d4f6138342a0eabc8"
+dependencies = [
+ "darling 0.24.1",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2293,6 +2523,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -2352,6 +2591,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy-regex"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4994ba703f78b083e2f7946dac9251abd83fd43a0365f030e99b69be5b4b9ef9"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd97232314824e6dbef1918a871bb93f51070455e3715bf26e19a6d01aa977a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2405,6 +2667,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -2414,6 +2682,12 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -2429,6 +2703,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru"
@@ -2498,7 +2781,7 @@ checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2543,6 +2826,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimad"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8b688969b16915f3ecadc7829d5b7779dee4977e503f767f34136803d5c06f"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2565,6 +2857,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -2588,7 +2881,7 @@ checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2749,7 +3042,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2861,7 +3154,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2934,7 +3227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2963,7 +3256,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -2972,7 +3265,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 2.0.117",
  "tempfile",
 ]
 
@@ -2983,10 +3276,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3153,6 +3446,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.11.0",
+ "cassowary",
+ "compact_str 0.8.2",
+ "crossterm 0.28.1",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru 0.12.5",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3178,7 +3492,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
 dependencies = [
  "either",
- "itertools",
+ "itertools 0.14.0",
  "rayon",
 ]
 
@@ -3235,7 +3549,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3255,9 +3569,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3278,9 +3592,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "region"
@@ -3361,6 +3675,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3369,7 +3705,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -3584,7 +3920,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3639,7 +3975,7 @@ checksum = "fd568a4c9bb598e291a08244a5c1f5a8a6650bee243b5b0f8dbb3d9cc1d87fe8"
 dependencies = [
  "bitflags 2.11.0",
  "cssparser",
- "derive_more",
+ "derive_more 0.99.20",
  "fxhash",
  "log",
  "new_debug_unreachable",
@@ -3689,7 +4025,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3700,7 +4036,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3797,6 +4133,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3877,6 +4234,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strict"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f42444fea5b87a39db4218d9422087e66a85d0e7a0963a439b07bcdf91804006"
+
+[[package]]
 name = "string_cache"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3908,6 +4271,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3918,6 +4303,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3941,7 +4337,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3973,7 +4369,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3986,6 +4382,22 @@ dependencies = [
  "futf",
  "mac",
  "utf-8",
+]
+
+[[package]]
+name = "termimad"
+version = "0.34.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "889a9370996b74cf46016ce35b96c248a9ac36d69aab1d112b3e09bc33affa49"
+dependencies = [
+ "coolor",
+ "crokey",
+ "crossbeam",
+ "lazy-regex",
+ "minimad",
+ "serde",
+ "thiserror 2.0.18",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -4014,7 +4426,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4025,7 +4437,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4070,12 +4482,12 @@ checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
 dependencies = [
  "ahash",
  "aho-corasick",
- "compact_str",
+ "compact_str 0.9.1",
  "dary_heap",
  "derive_builder",
  "esaxx-rs",
  "getrandom 0.3.4",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "macro_rules_attribute",
  "monostate",
@@ -4120,7 +4532,7 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4262,7 +4674,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4365,6 +4777,23 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -4527,7 +4956,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -4648,6 +5077,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4655,6 +5100,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -4677,7 +5128,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4688,7 +5139,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4911,7 +5362,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -4927,7 +5378,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -4994,7 +5445,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5015,7 +5466,7 @@ checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5035,7 +5486,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5075,7 +5526,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,6 +823,7 @@ dependencies = [
  "serde_json",
  "termimad",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]

--- a/apps/agent/src/daemon.rs
+++ b/apps/agent/src/daemon.rs
@@ -21,6 +21,7 @@ fn config() -> Result<Config> {
 
 pub async fn start() -> Result<()> {
     let config = config()?;
+    relocate()?;
     let store = Arc::new(Backend::open(&*crabup::dirs::STORE_FILE)?);
     tracing::info!("store at {}", crabup::dirs::STORE_FILE.display());
 
@@ -47,6 +48,26 @@ pub async fn start() -> Result<()> {
     let _ = std::fs::remove_file(&*crabup::dirs::PORT_FILE);
 
     store.checkpoint()
+}
+
+/// Move a store written before there was a directory to share.
+///
+/// The daemon is no longer the only thing here that keeps one, so its own
+/// went from the install root into `store/`. An install that predates
+/// that has agents and sessions in the old place, and leaving them there
+/// would read as having lost them.
+fn relocate() -> Result<()> {
+    let (from, to) = (
+        &*crabup::dirs::LEGACY_STORE_FILE,
+        &*crabup::dirs::STORE_FILE,
+    );
+    if !from.exists() || to.exists() {
+        return Ok(());
+    }
+    std::fs::create_dir_all(&*crabup::dirs::STORE_DIR)?;
+    std::fs::rename(from, to)?;
+    tracing::info!("moved the store to {}", to.display());
+    Ok(())
 }
 
 /// SIGTERM is how whatever spawned this kills it; ctrl-c is the terminal case.

--- a/apps/code/Cargo.toml
+++ b/apps/code/Cargo.toml
@@ -25,9 +25,13 @@ store.workspace = true
 
 anyhow.workspace = true
 chrono.workspace = true
+crossterm.workspace = true
 futures-util.workspace = true
+heck.workspace = true
+ratatui.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["rt", "fs"] }
+termimad.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/apps/code/Cargo.toml
+++ b/apps/code/Cargo.toml
@@ -25,6 +25,7 @@ store.workspace = true
 
 anyhow.workspace = true
 chrono.workspace = true
+crabllm-core.workspace = true
 crossterm.workspace = true
 futures-util.workspace = true
 heck.workspace = true

--- a/apps/code/Cargo.toml
+++ b/apps/code/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "crabtalk-code"
+description = "The Crabtalk coding agent"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+keywords.workspace = true
+
+[[bin]]
+name = "crab"
+path = "src/bin/main.rs"
+
+[features]
+default = ["native-tls"]
+native-tls = ["crabtalk/native-tls"]
+rustls = ["crabtalk/rustls"]
+
+[dependencies]
+crabtalk.workspace = true
+crabup.workspace = true
+proto = { workspace = true, features = ["server"] }
+store.workspace = true
+
+anyhow.workspace = true
+chrono.workspace = true
+futures-util.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["rt", "fs"] }
+tracing.workspace = true
+tracing-subscriber.workspace = true

--- a/apps/code/Cargo.toml
+++ b/apps/code/Cargo.toml
@@ -32,6 +32,7 @@ ratatui.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["rt", "fs"] }
+toml.workspace = true
 termimad.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/apps/code/src/backend/agent.rs
+++ b/apps/code/src/backend/agent.rs
@@ -1,0 +1,87 @@
+//! Agents, one file each.
+//!
+//! There is no name index. A name is found by reading the configs, which
+//! for a store holding a handful of agents costs less than an index that
+//! can disagree with them.
+
+use crate::backend::{self, Backend};
+use anyhow::Result;
+use std::str::FromStr;
+use store::{
+    AgentConfig, AgentId,
+    interface::{Agents, validate_table_name},
+};
+
+impl Backend {
+    fn agent_path(&self, id: &AgentId) -> std::path::PathBuf {
+        self.agents_dir()
+            .join(format!("{}.json", backend::encode(&id.to_string())))
+    }
+
+    fn default_agent_path(&self) -> std::path::PathBuf {
+        self.agents_dir().join("default")
+    }
+
+    /// Every stored config, in name order.
+    async fn all_agents(&self) -> Result<Vec<AgentConfig>> {
+        let mut out = Vec::new();
+        for name in backend::names_in(&self.agents_dir(), ".json").await? {
+            let Ok(id) = AgentId::from_str(&name) else {
+                continue;
+            };
+            if let Some(config) = backend::read_json(&self.agent_path(&id)).await? {
+                out.push(config);
+            }
+        }
+        out.sort_by(|a: &AgentConfig, b: &AgentConfig| a.name.cmp(&b.name));
+        Ok(out)
+    }
+}
+
+impl Agents for Backend {
+    async fn load_agent(&self, id: &AgentId) -> Result<Option<AgentConfig>> {
+        backend::read_json(&self.agent_path(id)).await
+    }
+
+    async fn load_agent_by_name(&self, name: &str) -> Result<Option<AgentConfig>> {
+        Ok(self
+            .all_agents()
+            .await?
+            .into_iter()
+            .find(|c| c.name == name))
+    }
+
+    async fn agent_ids(&self) -> Result<Vec<AgentId>> {
+        Ok(self.all_agents().await?.into_iter().map(|c| c.id).collect())
+    }
+
+    async fn upsert_agent(&self, config: &AgentConfig) -> Result<()> {
+        validate_table_name("agent", &config.name)?;
+        backend::write_json(&self.agent_path(&config.id), config).await
+    }
+
+    async fn delete_agent(&self, id: &AgentId) -> Result<bool> {
+        Ok(tokio::fs::remove_file(self.agent_path(id)).await.is_ok())
+    }
+
+    async fn rename_agent(&self, id: &AgentId, new_name: &str) -> Result<bool> {
+        validate_table_name("agent", new_name)?;
+        let Some(mut config) = self.load_agent(id).await? else {
+            return Ok(false);
+        };
+        config.name = new_name.to_owned();
+        backend::write_json(&self.agent_path(id), &config).await?;
+        Ok(true)
+    }
+
+    async fn default_agent(&self) -> Result<Option<AgentId>> {
+        let Ok(raw) = tokio::fs::read_to_string(self.default_agent_path()).await else {
+            return Ok(None);
+        };
+        Ok(AgentId::from_str(raw.trim()).ok())
+    }
+
+    async fn set_default_agent(&self, id: &AgentId) -> Result<()> {
+        Ok(tokio::fs::write(self.default_agent_path(), id.to_string()).await?)
+    }
+}

--- a/apps/code/src/backend/event.rs
+++ b/apps/code/src/backend/event.rs
@@ -1,0 +1,42 @@
+//! Standing subscriptions, in one file.
+//!
+//! They are rewritten whenever one is added, dropped, or fires once, so
+//! there is nothing an append would buy over a whole document.
+
+use crate::backend::{self, Backend};
+use anyhow::Result;
+use store::{EventSubscription, interface::Subscriptions};
+
+impl Backend {
+    fn subscriptions_path(&self) -> std::path::PathBuf {
+        self.root.join("subscriptions.json")
+    }
+}
+
+impl Subscriptions for Backend {
+    async fn subscriptions(&self) -> Result<Vec<EventSubscription>> {
+        Ok(backend::read_json(&self.subscriptions_path())
+            .await?
+            .unwrap_or_default())
+    }
+
+    async fn put_subscription(&self, sub: &EventSubscription) -> Result<()> {
+        let mut subs = self.subscriptions().await?;
+        match subs.iter_mut().find(|held| held.id == sub.id) {
+            Some(held) => *held = sub.clone(),
+            None => subs.push(sub.clone()),
+        }
+        backend::write_json(&self.subscriptions_path(), &subs).await
+    }
+
+    async fn remove_subscription(&self, id: u64) -> Result<bool> {
+        let mut subs = self.subscriptions().await?;
+        let before = subs.len();
+        subs.retain(|sub| sub.id != id);
+        if subs.len() == before {
+            return Ok(false);
+        }
+        backend::write_json(&self.subscriptions_path(), &subs).await?;
+        Ok(true)
+    }
+}

--- a/apps/code/src/backend/harness.rs
+++ b/apps/code/src/backend/harness.rs
@@ -1,0 +1,44 @@
+//! Harness images, one file per digest.
+//!
+//! An image is immutable under its digest, so re-putting the same bytes
+//! rewrites the same file and only the name pointer moves.
+
+use crate::backend::{self, Backend};
+use anyhow::Result;
+use store::interface::{self, Harnesses};
+
+impl Backend {
+    fn image_path(&self, digest: &str) -> std::path::PathBuf {
+        self.harnesses_dir().join(backend::encode(digest))
+    }
+
+    fn harness_name_path(&self, name: &str) -> std::path::PathBuf {
+        self.harnesses_dir()
+            .join("names")
+            .join(backend::encode(name))
+    }
+}
+
+impl Harnesses for Backend {
+    async fn harness_image(&self, digest: &str) -> Result<Option<Vec<u8>>> {
+        Ok(tokio::fs::read(self.image_path(digest)).await.ok())
+    }
+
+    async fn put_harness_image(&self, name: &str, bytes: &[u8]) -> Result<String> {
+        let digest = interface::digest(bytes);
+        tokio::fs::write(self.image_path(&digest), bytes).await?;
+        let pointer = self.harness_name_path(name);
+        if let Some(parent) = pointer.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        tokio::fs::write(pointer, &digest).await?;
+        Ok(digest)
+    }
+
+    async fn resolve_harness(&self, name: &str) -> Result<Option<String>> {
+        Ok(tokio::fs::read_to_string(self.harness_name_path(name))
+            .await
+            .ok()
+            .map(|digest| digest.trim().to_owned()))
+    }
+}

--- a/apps/code/src/backend/memory.rs
+++ b/apps/code/src/backend/memory.rs
@@ -1,0 +1,63 @@
+//! Memory entries, one file each.
+
+use crate::backend::{
+    self, Backend,
+    search::{self, Doc},
+};
+use anyhow::Result;
+use store::{MemoryEntry, interface::Memory};
+
+impl Backend {
+    fn memory_path(&self, name: &str) -> std::path::PathBuf {
+        self.memory_dir()
+            .join(format!("{}.json", backend::encode(name)))
+    }
+}
+
+impl Memory for Backend {
+    async fn memory(&self, name: &str) -> Result<Option<MemoryEntry>> {
+        backend::read_json(&self.memory_path(name)).await
+    }
+
+    async fn memory_names(&self) -> Result<Vec<String>> {
+        backend::names_in(&self.memory_dir(), ".json").await
+    }
+
+    async fn memory_names_under(&self, stem: &str) -> Result<Vec<String>> {
+        Ok(self
+            .memory_names()
+            .await?
+            .into_iter()
+            .filter(|name| name.starts_with(stem))
+            .collect())
+    }
+
+    async fn put_memory(&self, entry: &MemoryEntry) -> Result<()> {
+        backend::write_json(&self.memory_path(&entry.name), entry).await
+    }
+
+    async fn remove_memory(&self, name: &str) -> Result<bool> {
+        Ok(tokio::fs::remove_file(self.memory_path(name)).await.is_ok())
+    }
+
+    /// Aliases are alternative search terms, so they rank as part of the
+    /// entry rather than as names of their own.
+    async fn search_memory(&self, query: &str, limit: usize) -> Result<Vec<String>> {
+        let (mut names, mut docs) = (Vec::new(), Vec::new());
+        for name in self.memory_names().await? {
+            let Some(entry) = self.memory(&name).await? else {
+                continue;
+            };
+            let text = match entry.aliases.is_empty() {
+                true => entry.content,
+                false => format!("{}\n{}", entry.aliases.join(" "), entry.content),
+            };
+            names.push(name);
+            docs.push(Doc { text, weight: 1.0 });
+        }
+        Ok(search::rank(&docs, query, limit)
+            .into_iter()
+            .map(|(at, _)| names[at].clone())
+            .collect())
+    }
+}

--- a/apps/code/src/backend/mod.rs
+++ b/apps/code/src/backend/mod.rs
@@ -1,0 +1,188 @@
+//! Crab's store: the six interfaces over a directory.
+//!
+//! No key-value primitive underneath. A session is a directory of JSONL,
+//! memory and skills are files, and that partition is what lets two
+//! `crab` processes write at once — they never hold the same file.
+//!
+//! A name arrives from a person or a model and has to become a filename,
+//! so anything outside `[A-Za-z0-9._-]` is percent-encoded. Two names
+//! differing only in case still collide on a case-insensitive
+//! filesystem; that is the filesystem's property, not one this encoding
+//! tries to hide.
+
+use anyhow::Result;
+use serde::{Serialize, de::DeserializeOwned};
+use std::path::{Path, PathBuf};
+
+mod agent;
+mod event;
+mod harness;
+mod memory;
+mod search;
+mod session;
+mod skill;
+
+/// One crab install's state, rooted at a directory.
+pub struct Backend {
+    pub root: PathBuf,
+}
+
+impl Backend {
+    /// Open a store, creating the directories it writes into.
+    pub fn open(root: impl Into<PathBuf>) -> Result<Self> {
+        let root = root.into();
+        for dir in ["agents", "sessions", "memory", "skills", "harnesses"] {
+            std::fs::create_dir_all(root.join(dir))?;
+        }
+        Ok(Self { root })
+    }
+
+    pub(crate) fn agents_dir(&self) -> PathBuf {
+        self.root.join("agents")
+    }
+
+    pub(crate) fn sessions_dir(&self) -> PathBuf {
+        self.root.join("sessions")
+    }
+
+    pub(crate) fn memory_dir(&self) -> PathBuf {
+        self.root.join("memory")
+    }
+
+    pub(crate) fn skills_dir(&self) -> PathBuf {
+        self.root.join("skills")
+    }
+
+    pub(crate) fn harnesses_dir(&self) -> PathBuf {
+        self.root.join("harnesses")
+    }
+}
+
+/// Filename-safe form of a name, reversed by [`decode`].
+pub(crate) fn encode(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    for byte in name.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'.' | b'_' | b'-' => out.push(byte as char),
+            _ => out.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    out
+}
+
+/// The name a filename was encoded from. A filename this never produced
+/// decodes to itself rather than erroring — a directory can hold files
+/// nothing here wrote.
+pub(crate) fn decode(name: &str) -> String {
+    let bytes = name.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut at = 0;
+    while at < bytes.len() {
+        if bytes[at] == b'%' && at + 2 < bytes.len() {
+            let hex = std::str::from_utf8(&bytes[at + 1..at + 3]).unwrap_or_default();
+            if let Ok(byte) = u8::from_str_radix(hex, 16) {
+                out.push(byte);
+                at += 3;
+                continue;
+            }
+        }
+        out.push(bytes[at]);
+        at += 1;
+    }
+    String::from_utf8(out).unwrap_or_else(|_| name.to_owned())
+}
+
+/// Names in a directory, decoded, with `suffix` stripped. Ascending, and
+/// empty when the directory does not exist.
+pub(crate) async fn names_in(dir: &Path, suffix: &str) -> Result<Vec<String>> {
+    let Ok(mut entries) = tokio::fs::read_dir(dir).await else {
+        return Ok(Vec::new());
+    };
+    let mut out = Vec::new();
+    while let Some(entry) = entries.next_entry().await? {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let Some(stem) = name.strip_suffix(suffix) else {
+            continue;
+        };
+        out.push(decode(stem));
+    }
+    out.sort();
+    Ok(out)
+}
+
+pub(crate) async fn read_json<T: DeserializeOwned>(path: &Path) -> Result<Option<T>> {
+    let Ok(bytes) = tokio::fs::read(path).await else {
+        return Ok(None);
+    };
+    Ok(Some(serde_json::from_slice(&bytes)?))
+}
+
+/// Write through a temporary file, so a reader never sees half of one and
+/// two writers race to a whole document rather than into each other.
+pub(crate) async fn write_json<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let tmp = path.with_extension("tmp");
+    tokio::fs::write(&tmp, serde_json::to_vec_pretty(value)?).await?;
+    Ok(tokio::fs::rename(&tmp, path).await?)
+}
+
+/// Append one JSON document as a line. Every writer of a given file is
+/// the one process that owns the session, so an append needs no lock.
+pub(crate) async fn append_json<T: Serialize>(path: &Path, values: &[T]) -> Result<()> {
+    use tokio::io::AsyncWriteExt;
+
+    if values.is_empty() {
+        return Ok(());
+    }
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let mut buf = Vec::new();
+    for value in values {
+        buf.extend_from_slice(&serde_json::to_vec(value)?);
+        buf.push(b'\n');
+    }
+    let mut file = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .await?;
+    Ok(file.write_all(&buf).await?)
+}
+
+/// Every JSON line of a file. A torn final line — a crash mid-append —
+/// is dropped, the way a torn record ends a log replay.
+pub(crate) async fn read_lines<T: DeserializeOwned>(path: &Path) -> Result<Vec<T>> {
+    let Ok(bytes) = tokio::fs::read(path).await else {
+        return Ok(Vec::new());
+    };
+    let mut out = Vec::new();
+    for line in bytes.split(|b| *b == b'\n') {
+        if line.is_empty() {
+            continue;
+        }
+        match serde_json::from_slice(line) {
+            Ok(value) => out.push(value),
+            Err(e) => tracing::warn!("{}: discarding unreadable line: {e}", path.display()),
+        }
+    }
+    Ok(out)
+}
+
+/// Rewrite a file's lines. Used where an append cannot express the change
+/// — truncation, and dropping one entry from a set.
+pub(crate) async fn write_lines<T: Serialize>(path: &Path, values: &[T]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let mut buf = Vec::new();
+    for value in values {
+        buf.extend_from_slice(&serde_json::to_vec(value)?);
+        buf.push(b'\n');
+    }
+    let tmp = path.with_extension("tmp");
+    tokio::fs::write(&tmp, buf).await?;
+    Ok(tokio::fs::rename(&tmp, path).await?)
+}

--- a/apps/code/src/backend/search.rs
+++ b/apps/code/src/backend/search.rs
@@ -1,0 +1,69 @@
+//! Ranking for a store that keeps no inverted index.
+//!
+//! BM25 needs a corpus, and one with no postings on disk gets it by
+//! reading what it holds. The formula and its constants are the ones in
+//! `store::text`, and the tokenizer is literally that module's, so a
+//! query ranks the same here as it does against the daemon.
+
+use store::text;
+
+/// BM25's two knobs, as `store::text` publishes them.
+const K1: f64 = 1.2;
+const B: f64 = 0.75;
+
+/// One document to rank: its text, and what a match in it is worth.
+pub struct Doc {
+    pub text: String,
+    pub weight: f64,
+}
+
+/// Indices into `docs` with their scores, best first, at most `limit`.
+///
+/// An empty or all-stopword query ranks nothing rather than everything —
+/// a search box is allowed to contain junk.
+pub fn rank(docs: &[Doc], query: &str, limit: usize) -> Vec<(usize, f64)> {
+    let terms: Vec<String> = text::tokenize(query)
+        .into_iter()
+        .filter(|t| !text::is_stopword(t))
+        .collect();
+    if terms.is_empty() || limit == 0 || docs.is_empty() {
+        return Vec::new();
+    }
+
+    let tokenized: Vec<Vec<String>> = docs.iter().map(|d| text::tokenize(&d.text)).collect();
+    let n = docs.len() as f64;
+    let avgdl = tokenized.iter().map(|t| t.len()).sum::<usize>() as f64 / n;
+    if avgdl == 0.0 {
+        return Vec::new();
+    }
+
+    let mut scores = vec![0.0f64; docs.len()];
+    for term in &terms {
+        let counts: Vec<usize> = tokenized
+            .iter()
+            .map(|doc| doc.iter().filter(|t| *t == term).count())
+            .collect();
+        let df = counts.iter().filter(|c| **c > 0).count() as f64;
+        if df == 0.0 {
+            continue;
+        }
+        let idf = ((n - df + 0.5) / (df + 0.5) + 1.0).ln();
+        for (at, tf) in counts.iter().enumerate() {
+            if *tf == 0 {
+                continue;
+            }
+            let (tf, dl) = (*tf as f64, tokenized[at].len() as f64);
+            let norm = (tf * (K1 + 1.0)) / (tf + K1 * (1.0 - B + B * dl / avgdl));
+            scores[at] += idf * norm * docs[at].weight;
+        }
+    }
+
+    let mut ranked: Vec<(usize, f64)> = scores
+        .into_iter()
+        .enumerate()
+        .filter(|(_, score)| *score > 0.0)
+        .collect();
+    ranked.sort_by(|a, b| b.1.total_cmp(&a.1));
+    ranked.truncate(limit);
+    ranked
+}

--- a/apps/code/src/backend/search.rs
+++ b/apps/code/src/backend/search.rs
@@ -1,15 +1,11 @@
 //! Ranking for a store that keeps no inverted index.
 //!
 //! BM25 needs a corpus, and one with no postings on disk gets it by
-//! reading what it holds. The formula and its constants are the ones in
-//! `store::text`, and the tokenizer is literally that module's, so a
-//! query ranks the same here as it does against the daemon.
+//! reading what it holds. The formula and the tokenizer are both
+//! `store::text`'s, so a query ranks the same here as against a store
+//! that keeps postings — only where the counts come from differs.
 
-use store::text;
-
-/// BM25's two knobs, as `store::text` publishes them.
-const K1: f64 = 1.2;
-const B: f64 = 0.75;
+use store::text::{self, Bm25};
 
 /// One document to rank: its text, and what a match in it is worth.
 pub struct Doc {
@@ -31,30 +27,29 @@ pub fn rank(docs: &[Doc], query: &str, limit: usize) -> Vec<(usize, f64)> {
     }
 
     let tokenized: Vec<Vec<String>> = docs.iter().map(|d| text::tokenize(&d.text)).collect();
-    let n = docs.len() as f64;
-    let avgdl = tokenized.iter().map(|t| t.len()).sum::<usize>() as f64 / n;
+    let avgdl = tokenized.iter().map(|doc| doc.len()).sum::<usize>() as f64 / docs.len() as f64;
     if avgdl == 0.0 {
         return Vec::new();
     }
 
+    let bm25 = Bm25::default();
     let mut scores = vec![0.0f64; docs.len()];
     for term in &terms {
         let counts: Vec<usize> = tokenized
             .iter()
             .map(|doc| doc.iter().filter(|t| *t == term).count())
             .collect();
-        let df = counts.iter().filter(|c| **c > 0).count() as f64;
-        if df == 0.0 {
+        let df = counts.iter().filter(|count| **count > 0).count();
+        if df == 0 {
             continue;
         }
-        let idf = ((n - df + 0.5) / (df + 0.5) + 1.0).ln();
+        let idf = bm25.idf(df, docs.len());
         for (at, tf) in counts.iter().enumerate() {
             if *tf == 0 {
                 continue;
             }
-            let (tf, dl) = (*tf as f64, tokenized[at].len() as f64);
-            let norm = (tf * (K1 + 1.0)) / (tf + K1 * (1.0 - B + B * dl / avgdl));
-            scores[at] += idf * norm * docs[at].weight;
+            let len = tokenized[at].len() as u32;
+            scores[at] += idf * bm25.weigh(*tf as u32, len, avgdl) * docs[at].weight;
         }
     }
 

--- a/apps/code/src/backend/session.rs
+++ b/apps/code/src/backend/session.rs
@@ -1,0 +1,312 @@
+//! Sessions, one directory each: metadata, messages, and the trace.
+//!
+//! A message's index is its line number, which is what lets a hit point
+//! at one and a window read around it without an index to maintain.
+
+use crate::backend::{
+    self, Backend,
+    search::{self, Doc},
+};
+use anyhow::Result;
+use std::{collections::BTreeMap, path::PathBuf};
+use store::{
+    AgentId, EventLine, HistoryEntry, MAX_HITS_PER_QUERY, MAX_WINDOW_ITEMS, SearchOptions,
+    SessionHandle, SessionHit, SessionMeta, SessionSnapshot, Weights, WindowItem,
+    interface::{Agents, Sessions},
+};
+
+impl Backend {
+    fn session_dir(&self, handle: &SessionHandle) -> PathBuf {
+        self.sessions_dir().join(backend::encode(handle.as_str()))
+    }
+
+    fn meta_path(&self, handle: &SessionHandle) -> PathBuf {
+        self.session_dir(handle).join("meta.json")
+    }
+
+    fn messages_path(&self, handle: &SessionHandle) -> PathBuf {
+        self.session_dir(handle).join("messages.jsonl")
+    }
+
+    fn events_path(&self, handle: &SessionHandle) -> PathBuf {
+        self.session_dir(handle).join("events.jsonl")
+    }
+
+    fn archive_path(&self, handle: &SessionHandle) -> PathBuf {
+        self.session_dir(handle).join("archive")
+    }
+
+    async fn meta(&self, handle: &SessionHandle) -> Result<Option<SessionMeta>> {
+        backend::read_json(&self.meta_path(handle)).await
+    }
+
+    async fn messages(&self, handle: &SessionHandle) -> Result<Vec<HistoryEntry>> {
+        backend::read_lines(&self.messages_path(handle)).await
+    }
+
+    async fn handles(&self) -> Result<Vec<SessionHandle>> {
+        let Ok(mut entries) = tokio::fs::read_dir(self.sessions_dir()).await else {
+            return Ok(Vec::new());
+        };
+        let mut out = Vec::new();
+        while let Some(entry) = entries.next_entry().await? {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            out.push(SessionHandle::new(backend::decode(&name)));
+        }
+        out.sort();
+        Ok(out)
+    }
+
+    /// The messages surrounding a hit, bounded by [`MAX_WINDOW_ITEMS`].
+    fn window(&self, history: &[HistoryEntry], at: usize, opts: &SearchOptions) -> Vec<WindowItem> {
+        let before = opts.context_before.min(MAX_WINDOW_ITEMS);
+        let after = opts.context_after.min(MAX_WINDOW_ITEMS);
+        let first = at.saturating_sub(before);
+        let last = at
+            .saturating_add(after)
+            .min(history.len().saturating_sub(1));
+        let mut out = Vec::new();
+        for (idx, entry) in history.iter().enumerate().take(last + 1).skip(first) {
+            if out.len() >= MAX_WINDOW_ITEMS {
+                break;
+            }
+            let (snippet, truncated) = entry.snippet();
+            out.push(WindowItem {
+                role: entry.role().clone(),
+                msg_idx: idx as u32,
+                snippet,
+                truncated,
+                tool_name: entry.tool_name(),
+            });
+        }
+        out
+    }
+}
+
+impl Sessions for Backend {
+    async fn create_session(
+        &self,
+        handle: &SessionHandle,
+        agent: &AgentId,
+        created_by: &str,
+        root: Option<PathBuf>,
+    ) -> Result<()> {
+        let now = chrono::Utc::now().to_rfc3339();
+        let meta = SessionMeta {
+            agent: *agent,
+            created_by: created_by.to_owned(),
+            created_at: now.clone(),
+            title: String::new(),
+            updated_at: now,
+            message_count: 0,
+            summary: None,
+            root,
+        };
+        backend::write_json(&self.meta_path(handle), &meta).await
+    }
+
+    async fn load_session(&self, handle: &SessionHandle) -> Result<Option<SessionSnapshot>> {
+        let Some(meta) = self.meta(handle).await? else {
+            return Ok(None);
+        };
+        Ok(Some(SessionSnapshot {
+            meta,
+            history: self.messages(handle).await?,
+            archive: tokio::fs::read_to_string(self.archive_path(handle))
+                .await
+                .ok()
+                .map(|name| name.trim().to_owned()),
+        }))
+    }
+
+    async fn list_sessions(&self) -> Result<Vec<(SessionHandle, SessionMeta)>> {
+        let mut out = Vec::new();
+        for handle in self.handles().await? {
+            if let Some(meta) = self.meta(&handle).await? {
+                out.push((handle, meta));
+            }
+        }
+        out.sort_by(|(ah, am), (bh, bm)| {
+            bm.updated_at
+                .cmp(&am.updated_at)
+                .then_with(|| bm.created_at.cmp(&am.created_at))
+                .then_with(|| ah.as_str().cmp(bh.as_str()))
+        });
+        Ok(out)
+    }
+
+    async fn append_session_messages(
+        &self,
+        handle: &SessionHandle,
+        entries: &[HistoryEntry],
+    ) -> Result<()> {
+        if entries.is_empty() {
+            return Ok(());
+        }
+        let Some(mut meta) = self.meta(handle).await? else {
+            anyhow::bail!("session not found: {}", handle.as_str());
+        };
+        backend::append_json(&self.messages_path(handle), entries).await?;
+        meta.message_count += entries.len() as u64;
+        meta.updated_at = chrono::Utc::now().to_rfc3339();
+        backend::write_json(&self.meta_path(handle), &meta).await
+    }
+
+    async fn append_session_events(
+        &self,
+        handle: &SessionHandle,
+        events: &[EventLine],
+    ) -> Result<()> {
+        backend::append_json(&self.events_path(handle), events).await
+    }
+
+    /// The compacted prefix leaves the live history: the marker points at
+    /// where the text went, so the messages it covers are dropped rather
+    /// than kept beside it.
+    async fn append_session_compact(&self, handle: &SessionHandle, archive: &str) -> Result<()> {
+        self.truncate_session_messages(handle, 0).await?;
+        Ok(tokio::fs::write(self.archive_path(handle), archive).await?)
+    }
+
+    async fn truncate_session_messages(&self, handle: &SessionHandle, keep: usize) -> Result<()> {
+        let Some(mut meta) = self.meta(handle).await? else {
+            return Ok(());
+        };
+        let mut history = self.messages(handle).await?;
+        let kept = keep.min(history.len());
+        history.truncate(kept);
+        backend::write_lines(&self.messages_path(handle), &history).await?;
+        meta.message_count = kept as u64;
+        backend::write_json(&self.meta_path(handle), &meta).await
+    }
+
+    /// `message_count` is maintained by append and truncate, so the
+    /// stored value wins over whatever arrives here.
+    async fn update_session_meta(&self, handle: &SessionHandle, meta: &SessionMeta) -> Result<()> {
+        let mut meta = meta.clone();
+        if let Some(stored) = self.meta(handle).await? {
+            meta.message_count = stored.message_count;
+        }
+        backend::write_json(&self.meta_path(handle), &meta).await
+    }
+
+    async fn delete_session(&self, handle: &SessionHandle) -> Result<bool> {
+        Ok(tokio::fs::remove_dir_all(self.session_dir(handle))
+            .await
+            .is_ok())
+    }
+
+    async fn delete_sessions_of(&self, agent: &AgentId) -> Result<usize> {
+        let mut purged = 0;
+        for (handle, meta) in self.list_sessions().await? {
+            if meta.agent == *agent && self.delete_session(&handle).await? {
+                purged += 1;
+            }
+        }
+        Ok(purged)
+    }
+
+    /// Rank messages, keep each session's best, then boost by what the
+    /// session as a whole says about itself.
+    async fn search_sessions(&self, query: &str, opts: &SearchOptions) -> Result<Vec<SessionHit>> {
+        let weights = Weights::default();
+        let limit = opts.limit.clamp(1, MAX_HITS_PER_QUERY);
+        let candidates = limit.saturating_mul(weights.candidates_per_hit);
+
+        // One pass over the corpus builds both the message documents and
+        // the metadata ones, so a search reads each session once.
+        let mut loaded: Vec<(SessionHandle, SessionMeta, Vec<HistoryEntry>)> = Vec::new();
+        let (mut docs, mut located) = (Vec::new(), Vec::new());
+        let (mut meta_docs, mut meta_located) = (Vec::new(), Vec::new());
+        for (handle, meta) in self.list_sessions().await? {
+            let history = self.messages(&handle).await?;
+            let at = loaded.len();
+            for (idx, entry) in history.iter().enumerate() {
+                let Some((body, role)) = entry.indexable() else {
+                    continue;
+                };
+                let weight = match role {
+                    "user" => weights.user,
+                    "assistant_tool" => weights.tool_call,
+                    _ => 1.0,
+                };
+                docs.push(Doc { text: body, weight });
+                located.push((at, idx));
+            }
+            if !meta.title.is_empty() {
+                meta_docs.push(Doc {
+                    text: meta.title.clone(),
+                    weight: 1.0,
+                });
+                meta_located.push((at, weights.title_boost));
+            }
+            if let Some(summary) = &meta.summary {
+                meta_docs.push(Doc {
+                    text: summary.clone(),
+                    weight: 1.0,
+                });
+                meta_located.push((at, weights.summary_boost));
+            }
+            loaded.push((handle, meta, history));
+        }
+
+        // Best message per session.
+        let mut best: BTreeMap<usize, (usize, f64)> = BTreeMap::new();
+        for (doc, score) in search::rank(&docs, query, candidates) {
+            let (at, idx) = located[doc];
+            best.entry(at)
+                .and_modify(|held| {
+                    if score > held.1 {
+                        *held = (idx, score);
+                    }
+                })
+                .or_insert((idx, score));
+        }
+        if best.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut boosts: BTreeMap<usize, f64> = BTreeMap::new();
+        for (doc, _) in search::rank(&meta_docs, query, candidates) {
+            let (at, boost) = meta_located[doc];
+            *boosts.entry(at).or_insert(0.0) += boost;
+        }
+
+        let mut hits = Vec::new();
+        for (at, (idx, score)) in best {
+            let (handle, meta, history) = &loaded[at];
+            if opts.agent_filter.is_some_and(|id| meta.agent != id) {
+                continue;
+            }
+            if opts
+                .sender_filter
+                .as_ref()
+                .is_some_and(|s| &meta.created_by != s)
+            {
+                continue;
+            }
+            // A hit is read by a person or a model, and a bare ULID names
+            // nothing.
+            let agent_name = self
+                .load_agent(&meta.agent)
+                .await?
+                .map(|config| config.name)
+                .unwrap_or_default();
+            hits.push(SessionHit {
+                session_handle: handle.clone(),
+                msg_idx: idx as u32,
+                score: score + boosts.get(&at).copied().unwrap_or(0.0),
+                title: meta.title.clone(),
+                agent: meta.agent,
+                agent_name,
+                sender: meta.created_by.clone(),
+                created_at: meta.created_at.clone(),
+                updated_at: meta.updated_at.clone(),
+                window: self.window(history, idx, opts),
+            });
+        }
+        hits.sort_by(|a, b| b.score.total_cmp(&a.score));
+        hits.truncate(limit);
+        Ok(hits)
+    }
+}

--- a/apps/code/src/backend/skill.rs
+++ b/apps/code/src/backend/skill.rs
@@ -1,0 +1,50 @@
+//! Skills, one `SKILL.md` each.
+//!
+//! A listing reads the markdown it summarises. The keyed store splits
+//! the summary out so an enumeration never touches a body; here the body
+//! *is* the file, and a second document beside it would be a copy to
+//! keep in step for a catalogue one person installed by hand.
+
+use crate::backend::{self, Backend};
+use anyhow::Result;
+use std::str::FromStr;
+use store::{Skill, SkillSummary, interface::Skills};
+
+impl Backend {
+    fn skill_path(&self, name: &str) -> std::path::PathBuf {
+        self.skills_dir()
+            .join(format!("{}.md", backend::encode(name)))
+    }
+}
+
+impl Skills for Backend {
+    async fn list_skills(&self, limit: usize, offset: usize) -> Result<Vec<SkillSummary>> {
+        let names = backend::names_in(&self.skills_dir(), ".md").await?;
+        let mut out = Vec::new();
+        for name in names.iter().skip(offset).take(limit) {
+            if let Some(skill) = self.load_skill(name).await? {
+                out.push(SkillSummary::from(&skill));
+            }
+        }
+        Ok(out)
+    }
+
+    async fn load_skill(&self, name: &str) -> Result<Option<Skill>> {
+        let Ok(markdown) = tokio::fs::read_to_string(self.skill_path(name)).await else {
+            return Ok(None);
+        };
+        Ok(Some(Skill::from_str(&markdown)?))
+    }
+
+    /// The markdown is what is kept, so the name cannot disagree with the
+    /// frontmatter it came from.
+    async fn put_skill(&self, markdown: &str) -> Result<SkillSummary> {
+        let skill = Skill::from_str(markdown)?;
+        tokio::fs::write(self.skill_path(&skill.name), markdown).await?;
+        Ok(SkillSummary::from(&skill))
+    }
+
+    async fn remove_skill(&self, name: &str) -> Result<bool> {
+        Ok(tokio::fs::remove_file(self.skill_path(name)).await.is_ok())
+    }
+}

--- a/apps/code/src/bin/main.rs
+++ b/apps/code/src/bin/main.rs
@@ -13,6 +13,16 @@ async fn main() -> Result<()> {
         .with_max_level(tracing::Level::WARN)
         .init();
 
+    // An endpoint has to exist before the runtime is built over it, and
+    // asking for one is a conversation — which `-p` is not in.
+    if crabtalk_code::setup::needed(&store::Config::load(&crabup::dirs::CONFIG_FILE)?) {
+        match run {
+            Run::Print(_) => bail!("no model configured — run `crab` to set one up"),
+            Run::Chat if !crabtalk_code::setup::run().await? => return Ok(()),
+            Run::Chat => {}
+        }
+    }
+
     let crab = crabtalk_code::Crab::open(std::env::current_dir()?).await?;
     match run {
         Run::Print(prompt) => crab.turn(&prompt).await,

--- a/apps/code/src/bin/main.rs
+++ b/apps/code/src/bin/main.rs
@@ -1,0 +1,66 @@
+//! The crabtalk coding agent.
+
+use anyhow::{Result, bail};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let Some(prompt) = parse()? else {
+        return Ok(());
+    };
+
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_max_level(tracing::Level::WARN)
+        .init();
+
+    crabtalk_code::Crab::open(std::env::current_dir()?)
+        .await?
+        .turn(&prompt)
+        .await
+}
+
+fn usage() -> String {
+    let home = crabup::dirs::HOME_VAR;
+    format!(
+        "\
+crab — the crabtalk coding agent
+
+USAGE:
+    crab -p <PROMPT>
+
+OPTIONS:
+    -p, --print    Run one turn and write the answer to stdout
+    -h, --help     Print this message
+    -V, --version  Print the version
+
+ENVIRONMENT:
+    {home}  Install root (default: ~/.crabtalk)
+
+Tools are bound to the directory crab was started in.
+"
+    )
+}
+
+/// The prompt to run, or `None` when the argument printed and we are done.
+fn parse() -> Result<Option<String>> {
+    let mut args = std::env::args().skip(1);
+    let Some(arg) = args.next() else {
+        print!("{}", usage());
+        return Ok(None);
+    };
+    match arg.as_str() {
+        "-h" | "--help" => {
+            print!("{}", usage());
+            Ok(None)
+        }
+        "-V" | "--version" => {
+            println!("crab {}", env!("CARGO_PKG_VERSION"));
+            Ok(None)
+        }
+        "-p" | "--print" => match args.next() {
+            Some(prompt) => Ok(Some(prompt)),
+            None => bail!("-p takes a prompt\n\n{}", usage()),
+        },
+        other => bail!("unexpected argument: {other}\n\n{}", usage()),
+    }
+}

--- a/apps/code/src/bin/main.rs
+++ b/apps/code/src/bin/main.rs
@@ -4,7 +4,7 @@ use anyhow::{Result, bail};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let Some(prompt) = parse()? else {
+    let Some(run) = parse()? else {
         return Ok(());
     };
 
@@ -13,10 +13,19 @@ async fn main() -> Result<()> {
         .with_max_level(tracing::Level::WARN)
         .init();
 
-    crabtalk_code::Crab::open(std::env::current_dir()?)
-        .await?
-        .turn(&prompt)
-        .await
+    let crab = crabtalk_code::Crab::open(std::env::current_dir()?).await?;
+    match run {
+        Run::Print(prompt) => crab.turn(&prompt).await,
+        Run::Chat => crabtalk_code::tui::run(crab).await,
+    }
+}
+
+/// What the arguments asked for.
+enum Run {
+    /// One turn, to stdout.
+    Print(String),
+    /// The terminal session.
+    Chat,
 }
 
 fn usage() -> String {
@@ -26,7 +35,8 @@ fn usage() -> String {
 crab — the crabtalk coding agent
 
 USAGE:
-    crab -p <PROMPT>
+    crab            Start a session in this directory
+    crab -p <TEXT>  Run one turn and write the answer to stdout
 
 OPTIONS:
     -p, --print    Run one turn and write the answer to stdout
@@ -41,12 +51,11 @@ Tools are bound to the directory crab was started in.
     )
 }
 
-/// The prompt to run, or `None` when the argument printed and we are done.
-fn parse() -> Result<Option<String>> {
+/// What to run, or `None` when the argument printed and we are done.
+fn parse() -> Result<Option<Run>> {
     let mut args = std::env::args().skip(1);
     let Some(arg) = args.next() else {
-        print!("{}", usage());
-        return Ok(None);
+        return Ok(Some(Run::Chat));
     };
     match arg.as_str() {
         "-h" | "--help" => {
@@ -58,7 +67,7 @@ fn parse() -> Result<Option<String>> {
             Ok(None)
         }
         "-p" | "--print" => match args.next() {
-            Some(prompt) => Ok(Some(prompt)),
+            Some(prompt) => Ok(Some(Run::Print(prompt))),
             None => bail!("-p takes a prompt\n\n{}", usage()),
         },
         other => bail!("unexpected argument: {other}\n\n{}", usage()),

--- a/apps/code/src/crab.rs
+++ b/apps/code/src/crab.rs
@@ -1,0 +1,97 @@
+//! The coding agent: a runtime in this process, rooted where it started.
+//!
+//! No socket and no daemon. `crab` embeds the runtime the way the daemon
+//! does and skips the listeners, so the only thing between a keystroke
+//! and a tool call is a function call.
+
+use crate::backend::Backend;
+use anyhow::{Result, bail};
+use crabtalk::{Config, CrabTalk, CrabTalkHandle, system::provider::DefaultProvider};
+use futures_util::StreamExt;
+use proto::{CreateSessionMsg, StreamMsg, server::Server, stream_event::Event};
+use std::{path::PathBuf, sync::Arc};
+use store::{
+    AgentId, SessionHandle,
+    interface::{Agents, Sessions},
+};
+
+/// Where crab keeps its own state, beside the daemon's rather than in it.
+const STORE_DIR: &str = "store/code";
+
+pub struct Crab {
+    pub handle: CrabTalkHandle<DefaultProvider, Backend>,
+    pub agent: AgentId,
+    pub session: SessionHandle,
+    pub root: PathBuf,
+}
+
+impl Crab {
+    /// Start the runtime over `root`, resuming the session that directory
+    /// already has.
+    ///
+    /// The handle is the root's own path: running `crab` twice in one
+    /// checkout continues the conversation rather than starting a second.
+    pub async fn open(root: PathBuf) -> Result<Self> {
+        let config = Config {
+            settings: store::Config::load(&crabup::dirs::CONFIG_FILE)?,
+            harnesses: crabup::dirs::HARNESSES_DIR.clone(),
+            cache: crabup::dirs::CACHE_DIR.join("berm"),
+        };
+        let store = Arc::new(Backend::open(crabup::dirs::CONFIG_DIR.join(STORE_DIR))?);
+        let handle = CrabTalk::start(config, store.clone()).await?;
+
+        let Some(agent) = store.default_agent().await? else {
+            bail!("no default agent — the install did not scaffold one");
+        };
+        let session = SessionHandle::new(root.display().to_string());
+        if store.load_session(&session).await?.is_none() {
+            handle
+                .inner
+                .create_session(CreateSessionMsg {
+                    session_handle: session.as_str().to_owned(),
+                    agent: agent.to_string(),
+                    sender: None,
+                    root: Some(root.display().to_string()),
+                })
+                .await?;
+        }
+
+        Ok(Self {
+            handle,
+            agent,
+            session,
+            root,
+        })
+    }
+
+    /// Run one turn, writing the stream to stdout as it arrives.
+    pub async fn turn(&self, prompt: &str) -> Result<()> {
+        use std::io::Write;
+
+        let mut stream = std::pin::pin!(self.handle.inner.stream(StreamMsg {
+            agent: self.agent.to_string(),
+            content: prompt.to_owned(),
+            session_handle: self.session.as_str().to_owned(),
+            ..Default::default()
+        }));
+
+        while let Some(event) = stream.next().await {
+            let Some(event) = event?.event else { continue };
+            match event {
+                Event::Chunk(chunk) => {
+                    print!("{}", chunk.content);
+                    std::io::stdout().flush()?;
+                }
+                Event::ToolStart(start) => {
+                    for call in &start.calls {
+                        println!("\n⏺ {}", call.name);
+                    }
+                }
+                Event::End(end) if !end.error.is_empty() => bail!("{}", end.error),
+                Event::End(_) => println!(),
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+}

--- a/apps/code/src/crab.rs
+++ b/apps/code/src/crab.rs
@@ -11,7 +11,7 @@ use futures_util::StreamExt;
 use proto::{CreateSessionMsg, StreamMsg, server::Server, stream_event::Event};
 use std::{path::PathBuf, sync::Arc};
 use store::{
-    AgentId, HistoryEntry, SessionHandle,
+    AgentConfig, AgentId, HistoryEntry, SessionHandle,
     interface::{Agents, Sessions},
 };
 use tokio::sync::mpsc;
@@ -22,6 +22,7 @@ const STORE_DIR: &str = "store/code";
 pub struct Crab {
     pub handle: CrabTalkHandle<DefaultProvider, Backend>,
     pub store: Arc<Backend>,
+    pub config: AgentConfig,
     pub agent: AgentId,
     pub session: SessionHandle,
     pub root: PathBuf,
@@ -48,9 +49,10 @@ impl Crab {
         // The scaffolded agent is a bare one; what makes it a coding agent
         // is the prompt, so crab writes it every open rather than only on
         // the run that created the record.
-        if let Some(mut config) = store.load_agent(&agent).await?
-            && config.description != prompt::SYSTEM
-        {
+        let Some(mut config) = store.load_agent(&agent).await? else {
+            bail!("the default agent names no record");
+        };
+        if config.description != prompt::SYSTEM {
             config.description = prompt::SYSTEM.to_owned();
             store.upsert_agent(&config).await?;
         }
@@ -71,6 +73,7 @@ impl Crab {
         Ok(Self {
             handle,
             store,
+            config,
             agent,
             session,
             root,
@@ -88,6 +91,32 @@ impl Crab {
         let fresh = Self::open(self.root.clone()).await?;
         let stale = std::mem::replace(self, fresh);
         stale.handle.shutdown().await
+    }
+
+    /// Whether a call carrying `prompt_tokens` plus this agent's output
+    /// allowance would no longer fit the window.
+    ///
+    /// Not a fraction of the window chosen by anyone: the sum either fits
+    /// or it does not, and the answer is `false` whenever the window is
+    /// unknown rather than a guess at one.
+    pub fn overflows(&self, prompt_tokens: u32) -> bool {
+        let Some(window) = self.config.context_window else {
+            return false;
+        };
+        prompt_tokens.saturating_add(self.config.token_budget().0) >= window
+    }
+
+    /// Replace the history with a summary of it, and return the summary.
+    ///
+    /// The messages it covers are dropped rather than kept beside it, so
+    /// this is what the model works from afterwards. What is on screen is
+    /// untouched — scrollback is the record, and the record does not
+    /// shrink because the context did.
+    pub async fn compact(&self) -> Result<String> {
+        self.handle
+            .inner
+            .compact_conversation(self.session.as_str().to_owned(), prompt::COMPACT.to_owned())
+            .await
     }
 
     /// The turns this session already holds, oldest first.

--- a/apps/code/src/crab.rs
+++ b/apps/code/src/crab.rs
@@ -20,11 +20,11 @@ use tokio::sync::mpsc;
 const STORE_DIR: &str = "store/code";
 
 pub struct Crab {
-    pub handle: CrabTalkHandle<DefaultProvider, Backend>,
-    pub store: Arc<Backend>,
+    handle: CrabTalkHandle<DefaultProvider, Backend>,
+    store: Arc<Backend>,
     pub config: AgentConfig,
-    pub agent: AgentId,
-    pub session: SessionHandle,
+    agent: AgentId,
+    session: SessionHandle,
     pub root: PathBuf,
 }
 

--- a/apps/code/src/crab.rs
+++ b/apps/code/src/crab.rs
@@ -8,7 +8,7 @@ use crate::{backend::Backend, prompt};
 use anyhow::{Result, bail};
 use crabtalk::{Config, CrabTalk, CrabTalkHandle, system::provider::DefaultProvider};
 use futures_util::StreamExt;
-use proto::{CreateSessionMsg, StreamMsg, server::Server, stream_event::Event};
+use proto::{CancelStreamMsg, CreateSessionMsg, StreamMsg, server::Server, stream_event::Event};
 use std::{path::PathBuf, sync::Arc};
 use store::{
     AgentConfig, AgentId, HistoryEntry, SessionHandle,
@@ -52,8 +52,19 @@ impl Crab {
         let Some(mut config) = store.load_agent(&agent).await? else {
             bail!("the default agent names no record");
         };
-        if config.description != prompt::SYSTEM {
-            config.description = prompt::SYSTEM.to_owned();
+        // An agent scaffolded while the endpoint was unreachable named no
+        // model, and scaffolding does not run twice. Filling it here is
+        // the same rule the daemon uses — the first model the endpoint
+        // advertises — applied on a later run that can reach one.
+        let mut edited = config.description != prompt::SYSTEM;
+        config.description = prompt::SYSTEM.to_owned();
+        if config.model.is_empty()
+            && let Some(model) = handle.inner.list_models().await?.first()
+        {
+            config.model = model.name.clone();
+            edited = true;
+        }
+        if edited {
             store.upsert_agent(&config).await?;
         }
 
@@ -91,6 +102,20 @@ impl Crab {
         let fresh = Self::open(self.root.clone()).await?;
         let stale = std::mem::replace(self, fresh);
         stale.handle.shutdown().await
+    }
+
+    /// Stop the turn in flight, if there is one.
+    ///
+    /// Dropping the receiver only stops the reading: the tools keep
+    /// running against the developer's files, which is the half of a
+    /// cancel that matters.
+    pub async fn cancel(&self) -> Result<()> {
+        self.handle
+            .inner
+            .cancel_stream(CancelStreamMsg {
+                session_handle: self.session.as_str().to_owned(),
+            })
+            .await
     }
 
     /// Whether a call carrying `prompt_tokens` plus this agent's output
@@ -164,22 +189,20 @@ impl Crab {
         rx
     }
 
-    /// Run one turn, writing the stream to stdout as it arrives.
+    /// Run one turn, writing the answer to stdout as it arrives.
+    ///
+    /// The answer and nothing else — no markers, no tool activity. This
+    /// is the end of a pipe, and what reads it is a file or another
+    /// program rather than a person watching work happen.
     pub async fn turn(&self, prompt: &str) -> Result<()> {
         use std::io::Write;
 
         let mut events = self.spawn_turn(prompt);
         while let Some(event) = events.recv().await {
-            let event = event?;
-            match event {
+            match event? {
                 Event::Chunk(chunk) => {
                     print!("{}", chunk.content);
                     std::io::stdout().flush()?;
-                }
-                Event::ToolStart(start) => {
-                    for call in &start.calls {
-                        println!("\n⏺ {}", call.name);
-                    }
                 }
                 Event::End(end) if !end.error.is_empty() => bail!("{}", end.error),
                 Event::End(_) => println!(),

--- a/apps/code/src/crab.rs
+++ b/apps/code/src/crab.rs
@@ -4,14 +4,14 @@
 //! does and skips the listeners, so the only thing between a keystroke
 //! and a tool call is a function call.
 
-use crate::backend::Backend;
+use crate::{backend::Backend, prompt};
 use anyhow::{Result, bail};
 use crabtalk::{Config, CrabTalk, CrabTalkHandle, system::provider::DefaultProvider};
 use futures_util::StreamExt;
 use proto::{CreateSessionMsg, StreamMsg, server::Server, stream_event::Event};
 use std::{path::PathBuf, sync::Arc};
 use store::{
-    AgentId, SessionHandle,
+    AgentId, HistoryEntry, SessionHandle,
     interface::{Agents, Sessions},
 };
 use tokio::sync::mpsc;
@@ -21,6 +21,7 @@ const STORE_DIR: &str = "store/code";
 
 pub struct Crab {
     pub handle: CrabTalkHandle<DefaultProvider, Backend>,
+    pub store: Arc<Backend>,
     pub agent: AgentId,
     pub session: SessionHandle,
     pub root: PathBuf,
@@ -44,6 +45,16 @@ impl Crab {
         let Some(agent) = store.default_agent().await? else {
             bail!("no default agent — the install did not scaffold one");
         };
+        // The scaffolded agent is a bare one; what makes it a coding agent
+        // is the prompt, so crab writes it every open rather than only on
+        // the run that created the record.
+        if let Some(mut config) = store.load_agent(&agent).await?
+            && config.description != prompt::SYSTEM
+        {
+            config.description = prompt::SYSTEM.to_owned();
+            store.upsert_agent(&config).await?;
+        }
+
         let session = SessionHandle::new(root.display().to_string());
         if store.load_session(&session).await?.is_none() {
             handle
@@ -59,10 +70,34 @@ impl Crab {
 
         Ok(Self {
             handle,
+            store,
             agent,
             session,
             root,
         })
+    }
+
+    /// Rebuild the engine from the config as it now reads.
+    ///
+    /// The daemon has no reload — a live one does not re-read its config.
+    /// crab is not one: its runtime lasts as long as the session in front
+    /// of it, so pointing it at a gateway that has come back up is a
+    /// restart it can do without losing the conversation, which is in the
+    /// store either way.
+    pub async fn reconnect(&mut self) -> Result<()> {
+        let fresh = Self::open(self.root.clone()).await?;
+        let stale = std::mem::replace(self, fresh);
+        stale.handle.shutdown().await
+    }
+
+    /// The turns this session already holds, oldest first.
+    pub async fn history(&self) -> Result<Vec<HistoryEntry>> {
+        Ok(self
+            .store
+            .load_session(&self.session)
+            .await?
+            .map(|session| session.history)
+            .unwrap_or_default())
     }
 
     /// Start a turn, delivering its events on a channel.

--- a/apps/code/src/crab.rs
+++ b/apps/code/src/crab.rs
@@ -14,6 +14,7 @@ use store::{
     AgentId, SessionHandle,
     interface::{Agents, Sessions},
 };
+use tokio::sync::mpsc;
 
 /// Where crab keeps its own state, beside the daemon's rather than in it.
 const STORE_DIR: &str = "store/code";
@@ -64,19 +65,48 @@ impl Crab {
         })
     }
 
+    /// Start a turn, delivering its events on a channel.
+    ///
+    /// Spawned rather than returned as a stream so the caller can hold it
+    /// across a select loop, and drop it to walk away from a turn.
+    pub fn spawn_turn(&self, prompt: &str) -> mpsc::UnboundedReceiver<Result<Event>> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let (crabtalk, req) = (
+            self.handle.inner.clone(),
+            StreamMsg {
+                agent: self.agent.to_string(),
+                content: prompt.to_owned(),
+                session_handle: self.session.as_str().to_owned(),
+                ..Default::default()
+            },
+        );
+        tokio::spawn(async move {
+            let mut stream = std::pin::pin!(crabtalk.stream(req));
+            while let Some(event) = stream.next().await {
+                let event = match event {
+                    Ok(event) => event.event,
+                    Err(e) => {
+                        let _ = tx.send(Err(e));
+                        return;
+                    }
+                };
+                if let Some(event) = event
+                    && tx.send(Ok(event)).is_err()
+                {
+                    return;
+                }
+            }
+        });
+        rx
+    }
+
     /// Run one turn, writing the stream to stdout as it arrives.
     pub async fn turn(&self, prompt: &str) -> Result<()> {
         use std::io::Write;
 
-        let mut stream = std::pin::pin!(self.handle.inner.stream(StreamMsg {
-            agent: self.agent.to_string(),
-            content: prompt.to_owned(),
-            session_handle: self.session.as_str().to_owned(),
-            ..Default::default()
-        }));
-
-        while let Some(event) = stream.next().await {
-            let Some(event) = event?.event else { continue };
+        let mut events = self.spawn_turn(prompt);
+        while let Some(event) = events.recv().await {
+            let event = event?;
             match event {
                 Event::Chunk(chunk) => {
                     print!("{}", chunk.content);

--- a/apps/code/src/lib.rs
+++ b/apps/code/src/lib.rs
@@ -3,6 +3,7 @@
 pub use crab::Crab;
 
 pub mod backend;
+pub mod prompt;
 pub mod setup;
 pub mod tui;
 

--- a/apps/code/src/lib.rs
+++ b/apps/code/src/lib.rs
@@ -3,6 +3,7 @@
 pub use crab::Crab;
 
 pub mod backend;
+pub mod setup;
 pub mod tui;
 
 mod crab;

--- a/apps/code/src/lib.rs
+++ b/apps/code/src/lib.rs
@@ -5,6 +5,7 @@ pub use crab::Crab;
 pub mod backend;
 pub mod prompt;
 pub mod setup;
+pub mod term;
 pub mod tui;
 
 mod crab;

--- a/apps/code/src/lib.rs
+++ b/apps/code/src/lib.rs
@@ -3,5 +3,6 @@
 pub use crab::Crab;
 
 pub mod backend;
+pub mod tui;
 
 mod crab;

--- a/apps/code/src/lib.rs
+++ b/apps/code/src/lib.rs
@@ -1,0 +1,7 @@
+//! The Crabtalk coding agent.
+
+pub use crab::Crab;
+
+pub mod backend;
+
+mod crab;

--- a/apps/code/src/prompt.rs
+++ b/apps/code/src/prompt.rs
@@ -1,0 +1,32 @@
+//! What crab is told it is.
+//!
+//! The daemon supplies no prose — an agent's description *is* its system
+//! message, used verbatim. So this is the whole of it, and it lives with
+//! the product rather than with the agent record every install scaffolds.
+
+pub const SYSTEM: &str = "\
+You are crab, a coding agent working in a terminal alongside a developer.
+
+You work inside one directory tree and reach it through your tools: `bash` \
+to run commands, `read` to read a file, `edit` to change one, `glob` to find \
+files by name, and `grep` to search their contents. Paths are relative to \
+that tree and nothing outside it is reachable.
+
+Reach for `grep` and `glob` rather than running `grep`, `rg` or `find` \
+through `bash` — they are faster and their output is already shaped for you. \
+Use `bash` for the things only a shell does: building, running tests, git.
+
+`edit` replaces a string that appears exactly once in a file, and fails \
+otherwise. Naming such a string means already knowing what is there, so read \
+a file before editing it rather than guessing at a line.
+
+Prefer doing the work to describing it. Read the code before you change it, \
+follow what the surrounding file already does, and make the smallest change \
+that finishes the task. When something is ambiguous enough that two readings \
+would produce different work, ask instead of picking one.
+
+You are answering into a terminal. Keep prose short, skip preamble and \
+summary, and reference code as `path:line` so it can be opened. Do not \
+explain what a command you just ran does when its output is on screen.
+
+Never commit, push, or otherwise touch a remote unless you are asked to.";

--- a/apps/code/src/prompt.rs
+++ b/apps/code/src/prompt.rs
@@ -30,3 +30,22 @@ summary, and reference code as `path:line` so it can be opened. Do not \
 explain what a command you just ran does when its output is on screen.
 
 Never commit, push, or otherwise touch a remote unless you are asked to.";
+
+/// What crab asks for when a conversation is compacted.
+///
+/// The runtime refuses an empty one, and rightly: the summary replaces
+/// the history the model works from, so what to keep is the client's
+/// decision and nobody else can make it.
+pub const COMPACT: &str = "\
+Summarize this conversation so that you could pick the work up from the \
+summary alone, with none of the messages above it.
+
+Keep: what was being built and why, the decisions taken and what they \
+ruled out, the files touched and what changed in them, commands whose \
+output still matters, and anything the developer asked for that is not \
+done yet.
+
+Drop: tool output that has served its purpose, exploration that led \
+nowhere, and anything restated later.
+
+Write it as notes to yourself, not as a report to a reader.";

--- a/apps/code/src/setup/login.rs
+++ b/apps/code/src/setup/login.rs
@@ -1,0 +1,70 @@
+//! Logging in through the browser.
+//!
+//! The token comes back to a loopback listener rather than through a
+//! paste: the port is bound before the browser opens, so the callback has
+//! somewhere to land and nothing has to be copied by hand.
+
+use anyhow::{Result, bail};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+};
+
+/// Room for the callback's request line and headers.
+const REQUEST_BYTES: usize = 4096;
+
+const PAGE: &str = "HTTP/1.1 200 OK\r\n\
+    Content-Type: text/html\r\n\
+    Connection: close\r\n\r\n\
+    <html><body><h3>Logged in. You can close this tab.</h3></body></html>";
+
+/// Open the browser and wait for the callback to bring a token back.
+pub async fn token(cloud: &str) -> Result<String> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let port = listener.local_addr()?.port();
+    browser(&format!(
+        "{cloud}/auth/google?client=terminal&port={port}&scope=llm"
+    ))?;
+
+    let (mut stream, _) = listener.accept().await?;
+    let mut buf = vec![0u8; REQUEST_BYTES];
+    let read = stream.read(&mut buf).await?;
+    let request = String::from_utf8_lossy(&buf[..read]).into_owned();
+
+    let Some(token) = parse(&request) else {
+        bail!("the callback carried no token — the login did not finish");
+    };
+    stream.write_all(PAGE.as_bytes()).await?;
+    stream.shutdown().await?;
+    Ok(token)
+}
+
+/// The `token` query parameter of the callback's request line.
+fn parse(request: &str) -> Option<String> {
+    request
+        .lines()
+        .next()?
+        .split_whitespace()
+        .nth(1)?
+        .split('?')
+        .nth(1)?
+        .split('&')
+        .find_map(|pair| pair.strip_prefix("token=").map(str::to_owned))
+}
+
+fn browser(url: &str) -> Result<()> {
+    #[cfg(target_os = "macos")]
+    let opened = std::process::Command::new("open").arg(url).status();
+    #[cfg(target_os = "linux")]
+    let opened = std::process::Command::new("xdg-open").arg(url).status();
+    #[cfg(target_os = "windows")]
+    let opened = std::process::Command::new("cmd")
+        .args(["/C", "start", "", url])
+        .status();
+
+    match opened {
+        Ok(status) if status.success() => Ok(()),
+        Ok(status) => bail!("the browser exited with {status} — open {url} by hand"),
+        Err(e) => bail!("could not open a browser ({e}) — open {url} by hand"),
+    }
+}

--- a/apps/code/src/setup/mod.rs
+++ b/apps/code/src/setup/mod.rs
@@ -1,0 +1,233 @@
+//! First run: naming an endpoint, before there is one to talk to.
+//!
+//! It writes `[llm]` into the shared config, so what is set here is what
+//! the daemon reads too — there is one endpoint per install, not one per
+//! product.
+
+use anyhow::Result;
+use crossterm::{
+    event::{Event, EventStream, KeyCode, KeyEventKind},
+    terminal::{disable_raw_mode, enable_raw_mode},
+};
+use futures_util::StreamExt;
+use ratatui::{
+    Frame, Terminal, TerminalOptions, Viewport,
+    backend::CrosstermBackend,
+    layout::{Constraint, Layout},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+};
+
+mod login;
+
+/// Where a terminal logs in.
+const CLOUD: &str = "https://api-beta.crabtalk.ai";
+
+/// The endpoints an API key can name. `Custom` is not offered: it needs a
+/// base URL as well, which is a config file rather than a prompt.
+const KINDS: &[&str] = &["anthropic", "openai", "google", "ollama", "azure"];
+
+/// Rows the flow draws into — its longest screen, since an inline
+/// viewport cannot be resized after it is built.
+const VIEWPORT: u16 = 10;
+
+/// Whether nothing names an endpoint yet.
+pub fn needed(config: &store::Config) -> bool {
+    !config.llm.is_set() && config.providers.is_empty()
+}
+
+/// Ask how to reach a model, and write the answer to the config.
+///
+/// `Ok(false)` if the person walked away without choosing.
+pub async fn run() -> Result<bool> {
+    enable_raw_mode()?;
+    let hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = disable_raw_mode();
+        hook(info);
+    }));
+
+    let mut terminal = Terminal::with_options(
+        CrosstermBackend::new(std::io::stdout()),
+        TerminalOptions {
+            viewport: Viewport::Inline(VIEWPORT),
+        },
+    )?;
+    let result = ask(&mut terminal).await;
+
+    disable_raw_mode()?;
+    terminal.clear()?;
+    result
+}
+
+/// Which screen the flow is on.
+enum Screen {
+    /// Log in, or name a provider.
+    Method {
+        at: usize,
+    },
+    Provider {
+        at: usize,
+    },
+    Key {
+        kind: String,
+        key: String,
+    },
+    /// The browser is open and the callback has not arrived.
+    Waiting,
+}
+
+async fn ask(terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>) -> Result<bool> {
+    let mut screen = Screen::Method { at: 0 };
+    let mut keys = EventStream::new();
+
+    loop {
+        terminal.draw(|frame| view(frame, &screen))?;
+
+        // The browser flow waits on a socket rather than on a keystroke.
+        // Both are awaited so the wait can still be walked away from, and
+        // the future is held across the loop so a stray key does not
+        // reopen the browser.
+        if matches!(screen, Screen::Waiting) {
+            let mut pending = std::pin::pin!(login::token(CLOUD));
+            loop {
+                tokio::select! {
+                    token = &mut pending => {
+                        write(&[("base_url", format!("{CLOUD}/v1")), ("api_key", token?)])?;
+                        return Ok(true);
+                    }
+                    event = keys.next() => {
+                        let Some(Ok(Event::Key(key))) = event else { continue };
+                        if key.code == KeyCode::Esc {
+                            return Ok(false);
+                        }
+                    }
+                }
+            }
+        }
+
+        let Some(event) = keys.next().await else {
+            return Ok(false);
+        };
+        let Event::Key(key) = event? else { continue };
+        if key.kind != KeyEventKind::Press {
+            continue;
+        }
+
+        match (&mut screen, key.code) {
+            (_, KeyCode::Esc) => return Ok(false),
+            (Screen::Method { at }, KeyCode::Up) => *at = at.saturating_sub(1),
+            (Screen::Method { at }, KeyCode::Down) => *at = (*at + 1).min(1),
+            (Screen::Method { at }, KeyCode::Enter) => {
+                screen = match at {
+                    0 => Screen::Waiting,
+                    _ => Screen::Provider { at: 0 },
+                };
+            }
+            (Screen::Provider { at }, KeyCode::Up) => *at = at.saturating_sub(1),
+            (Screen::Provider { at }, KeyCode::Down) => *at = (*at + 1).min(KINDS.len() - 1),
+            (Screen::Provider { at }, KeyCode::Enter) => {
+                screen = Screen::Key {
+                    kind: KINDS[*at].to_owned(),
+                    key: String::new(),
+                };
+            }
+            (Screen::Key { key, .. }, KeyCode::Char(ch)) => key.push(ch),
+            (Screen::Key { key, .. }, KeyCode::Backspace) => {
+                key.pop();
+            }
+            (Screen::Key { kind, key }, KeyCode::Enter) if !key.is_empty() => {
+                write(&[("kind", kind.clone()), ("api_key", key.clone())])?;
+                return Ok(true);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn view(frame: &mut Frame, screen: &Screen) {
+    let dim = Style::new().add_modifier(Modifier::DIM);
+    let [title, body, hint] = Layout::vertical([
+        Constraint::Length(2),
+        Constraint::Min(0),
+        Constraint::Length(1),
+    ])
+    .areas(frame.area());
+
+    frame.render_widget(
+        Paragraph::new(vec![
+            Line::from(Span::styled(
+                "  crab needs a model to talk to",
+                Style::new().add_modifier(Modifier::BOLD),
+            )),
+            Line::raw(""),
+        ]),
+        title,
+    );
+
+    let lines = match screen {
+        Screen::Method { at } => options(&["Log in with crabtalk", "Use an API key"], *at),
+        Screen::Provider { at } => options(KINDS, *at),
+        Screen::Key { kind, key } => vec![
+            Line::from(Span::styled(format!("  {kind} api key"), dim)),
+            Line::raw(""),
+            Line::from(vec![
+                Span::styled("  ", dim),
+                Span::raw("•".repeat(key.chars().count())),
+                Span::styled("▏", dim),
+            ]),
+        ],
+        Screen::Waiting => vec![Line::from(Span::styled("  waiting for the browser…", dim))],
+    };
+    frame.render_widget(Paragraph::new(lines), body);
+
+    let keys = match screen {
+        Screen::Key { .. } => "  enter to save  ·  esc to cancel",
+        Screen::Waiting => "  esc to cancel",
+        _ => "  ↑↓ to choose  ·  enter to select  ·  esc to cancel",
+    };
+    frame.render_widget(Paragraph::new(Line::from(Span::styled(keys, dim))), hint);
+}
+
+fn options(labels: &[&str], at: usize) -> Vec<Line<'static>> {
+    labels
+        .iter()
+        .enumerate()
+        .map(|(idx, label)| {
+            let selected = idx == at;
+            let marker = match selected {
+                true => "  ❯ ",
+                false => "    ",
+            };
+            let style = match selected {
+                true => Style::new().add_modifier(Modifier::BOLD),
+                false => Style::new().add_modifier(Modifier::DIM),
+            };
+            Line::from(vec![
+                Span::styled(marker, style),
+                Span::styled((*label).to_owned(), style),
+            ])
+        })
+        .collect()
+}
+
+/// Merge keys into `[llm]`, leaving the rest of the file as written.
+fn write(entries: &[(&str, String)]) -> Result<()> {
+    let path = &*crabup::dirs::CONFIG_FILE;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let raw = std::fs::read_to_string(path).unwrap_or_default();
+    let mut doc: toml::Table = toml::from_str(&raw).unwrap_or_default();
+
+    let llm = doc
+        .entry("llm")
+        .or_insert_with(|| toml::Value::Table(Default::default()));
+    if let Some(table) = llm.as_table_mut() {
+        for (key, value) in entries {
+            table.insert((*key).to_owned(), toml::Value::String(value.clone()));
+        }
+    }
+    Ok(std::fs::write(path, toml::to_string_pretty(&doc)?)?)
+}

--- a/apps/code/src/setup/mod.rs
+++ b/apps/code/src/setup/mod.rs
@@ -4,14 +4,12 @@
 //! the daemon reads too — there is one endpoint per install, not one per
 //! product.
 
+use crate::term;
 use anyhow::Result;
-use crossterm::{
-    event::{Event, EventStream, KeyCode, KeyEventKind},
-    terminal::{disable_raw_mode, enable_raw_mode},
-};
+use crossterm::event::{Event, EventStream, KeyCode, KeyEventKind};
 use futures_util::StreamExt;
 use ratatui::{
-    Frame, Terminal, TerminalOptions, Viewport,
+    Frame, Terminal,
     backend::CrosstermBackend,
     layout::{Constraint, Layout},
     style::{Modifier, Style},
@@ -41,24 +39,8 @@ pub fn needed(config: &store::Config) -> bool {
 ///
 /// `Ok(false)` if the person walked away without choosing.
 pub async fn run() -> Result<bool> {
-    enable_raw_mode()?;
-    let hook = std::panic::take_hook();
-    std::panic::set_hook(Box::new(move |info| {
-        let _ = disable_raw_mode();
-        hook(info);
-    }));
-
-    let mut terminal = Terminal::with_options(
-        CrosstermBackend::new(std::io::stdout()),
-        TerminalOptions {
-            viewport: Viewport::Inline(VIEWPORT),
-        },
-    )?;
-    let result = ask(&mut terminal).await;
-
-    disable_raw_mode()?;
-    terminal.clear()?;
-    result
+    let mut terminal = term::Inline::open(VIEWPORT)?;
+    ask(&mut terminal).await
 }
 
 /// Which screen the flow is on.

--- a/apps/code/src/term.rs
+++ b/apps/code/src/term.rs
@@ -1,0 +1,79 @@
+//! The terminal, in raw mode with an inline viewport, and put back after.
+//!
+//! Two screens need this — naming an endpoint and talking to one — and
+//! the sequence is unforgiving in both: raw mode has to come off however
+//! the screen ends, including through a panic, or the shell that started
+//! it is left unusable.
+
+use anyhow::Result;
+use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
+use ratatui::{Terminal, TerminalOptions, Viewport, backend::CrosstermBackend};
+use std::{
+    io::Stdout,
+    ops::{Deref, DerefMut},
+    sync::Once,
+};
+
+/// Installed once. Wrapping the hook a second time would chain a second
+/// copy of itself onto the first.
+static HOOK: Once = Once::new();
+
+pub struct Inline {
+    terminal: Terminal<CrosstermBackend<Stdout>>,
+}
+
+impl Inline {
+    /// Take the terminal, keeping `rows` of it for the viewport.
+    ///
+    /// ratatui cannot resize an inline viewport once it is built, so
+    /// `rows` is the tallest the screen will ever be rather than what it
+    /// starts at.
+    pub fn open(rows: u16) -> Result<Self> {
+        enable_raw_mode()?;
+        // The panic message is printed before unwinding reaches `drop`,
+        // so it would land on a raw terminal without this.
+        HOOK.call_once(|| {
+            let hook = std::panic::take_hook();
+            std::panic::set_hook(Box::new(move |info| {
+                let _ = disable_raw_mode();
+                hook(info);
+            }));
+        });
+
+        let terminal = Terminal::with_options(
+            CrosstermBackend::new(std::io::stdout()),
+            TerminalOptions {
+                viewport: Viewport::Inline(rows),
+            },
+        );
+        match terminal {
+            Ok(terminal) => Ok(Self { terminal }),
+            Err(e) => {
+                let _ = disable_raw_mode();
+                Err(e.into())
+            }
+        }
+    }
+}
+
+impl Drop for Inline {
+    fn drop(&mut self) {
+        let _ = disable_raw_mode();
+        // Leave the viewport behind rather than on top of the prompt.
+        let _ = self.terminal.clear();
+    }
+}
+
+impl Deref for Inline {
+    type Target = Terminal<CrosstermBackend<Stdout>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.terminal
+    }
+}
+
+impl DerefMut for Inline {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.terminal
+    }
+}

--- a/apps/code/src/tui/command.rs
+++ b/apps/code/src/tui/command.rs
@@ -1,0 +1,33 @@
+//! What a line beginning with `/` asks for.
+
+/// The commands, and what each is for.
+pub const HELP: &[(&str, &str)] = &[
+    (
+        "/reconnect",
+        "rebuild the engine from the config as it now reads",
+    ),
+    ("/help", "this list"),
+    ("/exit", "leave"),
+];
+
+pub enum Command {
+    Reconnect,
+    Help,
+    Exit,
+    Unknown(String),
+}
+
+impl Command {
+    /// Parse a submitted line, or `None` when it is a message rather than
+    /// a command.
+    pub fn parse(line: &str) -> Option<Self> {
+        let line = line.trim();
+        let name = line.strip_prefix('/')?;
+        Some(match name {
+            "reconnect" => Self::Reconnect,
+            "help" => Self::Help,
+            "exit" | "quit" => Self::Exit,
+            other => Self::Unknown(other.to_owned()),
+        })
+    }
+}

--- a/apps/code/src/tui/command.rs
+++ b/apps/code/src/tui/command.rs
@@ -6,12 +6,17 @@ pub const HELP: &[(&str, &str)] = &[
         "/reconnect",
         "rebuild the engine from the config as it now reads",
     ),
+    (
+        "/compact",
+        "summarize the conversation and work from the summary",
+    ),
     ("/help", "this list"),
     ("/exit", "leave"),
 ];
 
 pub enum Command {
     Reconnect,
+    Compact,
     Help,
     Exit,
     Unknown(String),
@@ -25,6 +30,7 @@ impl Command {
         let name = line.strip_prefix('/')?;
         Some(match name {
             "reconnect" => Self::Reconnect,
+            "compact" => Self::Compact,
             "help" => Self::Help,
             "exit" | "quit" => Self::Exit,
             other => Self::Unknown(other.to_owned()),

--- a/apps/code/src/tui/input.rs
+++ b/apps/code/src/tui/input.rs
@@ -1,0 +1,290 @@
+//! The input box: a multi-line editor with history.
+//!
+//! It owns the bottom of the viewport and nothing else, so it is handed
+//! a `Rect` and draws into it — where the box sits is the loop's
+//! business.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph},
+};
+use std::path::Path;
+
+/// What a keystroke asked the loop to do.
+pub enum Action {
+    Submit(String),
+    /// Ctrl+C — cancel the turn, or clear the line.
+    Interrupt,
+    /// Ctrl+D on an empty line.
+    Eof,
+    Noop,
+}
+
+/// Submitted lines, oldest first, with a cursor for Up/Down recall.
+pub struct History {
+    entries: Vec<String>,
+    cursor: usize,
+    /// What was typed before recall started, restored on the way back.
+    stash: String,
+}
+
+impl History {
+    pub fn load(path: &Path) -> Self {
+        let entries: Vec<String> = std::fs::read_to_string(path)
+            .unwrap_or_default()
+            .lines()
+            .filter(|line| !line.is_empty())
+            .map(String::from)
+            .collect();
+        Self {
+            cursor: entries.len(),
+            entries,
+            stash: String::new(),
+        }
+    }
+
+    pub fn save(&self, path: &Path) {
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let _ = std::fs::write(path, self.entries.join("\n"));
+    }
+
+    fn push(&mut self, line: &str) {
+        let line = line.trim();
+        if line.is_empty() {
+            self.cursor = self.entries.len();
+            return;
+        }
+        if self.entries.last().map(String::as_str) != Some(line) {
+            self.entries.push(line.to_owned());
+        }
+        self.cursor = self.entries.len();
+    }
+
+    fn prev(&mut self, current: &str) -> Option<&str> {
+        if self.cursor == self.entries.len() {
+            self.stash = current.to_owned();
+        }
+        if self.cursor == 0 {
+            return None;
+        }
+        self.cursor -= 1;
+        Some(&self.entries[self.cursor])
+    }
+
+    fn next(&mut self) -> Option<&str> {
+        if self.cursor >= self.entries.len() {
+            return None;
+        }
+        self.cursor += 1;
+        match self.cursor == self.entries.len() {
+            true => Some(&self.stash),
+            false => Some(&self.entries[self.cursor]),
+        }
+    }
+}
+
+/// The text being typed, as lines and a cursor into them.
+struct Buffer {
+    lines: Vec<String>,
+    /// Row, then column in characters — never bytes, so a multi-byte
+    /// character moves the cursor once.
+    cursor: (usize, usize),
+}
+
+impl Buffer {
+    fn new() -> Self {
+        Self {
+            lines: vec![String::new()],
+            cursor: (0, 0),
+        }
+    }
+
+    fn from_str(text: &str) -> Self {
+        let lines: Vec<String> = match text.is_empty() {
+            true => vec![String::new()],
+            false => text.lines().map(String::from).collect(),
+        };
+        let last = lines.len() - 1;
+        let col = lines[last].chars().count();
+        Self {
+            cursor: (last, col),
+            lines,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.lines.len() == 1 && self.lines[0].is_empty()
+    }
+
+    fn content(&self) -> String {
+        self.lines.join("\n")
+    }
+
+    fn newline(&mut self) {
+        let (row, col) = self.cursor;
+        let at = byte_of(&self.lines[row], col);
+        let rest = self.lines[row][at..].to_owned();
+        self.lines[row].truncate(at);
+        self.lines.insert(row + 1, rest);
+        self.cursor = (row + 1, 0);
+    }
+
+    fn key(&mut self, code: KeyCode) {
+        let (row, col) = self.cursor;
+        match code {
+            KeyCode::Backspace if col == 0 && row > 0 => {
+                let joined = self.lines.remove(row);
+                self.cursor = (row - 1, self.lines[row - 1].chars().count());
+                self.lines[row - 1].push_str(&joined);
+            }
+            KeyCode::Left if col == 0 && row > 0 => {
+                self.cursor = (row - 1, self.lines[row - 1].chars().count());
+            }
+            KeyCode::Left => self.cursor.1 = col.saturating_sub(1),
+            KeyCode::Right if col >= self.lines[row].chars().count() => {
+                if row + 1 < self.lines.len() {
+                    self.cursor = (row + 1, 0);
+                }
+            }
+            KeyCode::Right => self.cursor.1 += 1,
+            KeyCode::Home => self.cursor.1 = 0,
+            KeyCode::End => self.cursor.1 = self.lines[row].chars().count(),
+            KeyCode::Backspace => {
+                let (from, to) = (
+                    byte_of(&self.lines[row], col - 1),
+                    byte_of(&self.lines[row], col),
+                );
+                self.lines[row].drain(from..to);
+                self.cursor.1 -= 1;
+            }
+            KeyCode::Delete if col < self.lines[row].chars().count() => {
+                let (from, to) = (
+                    byte_of(&self.lines[row], col),
+                    byte_of(&self.lines[row], col + 1),
+                );
+                self.lines[row].drain(from..to);
+            }
+            KeyCode::Char(ch) => {
+                let at = byte_of(&self.lines[row], col);
+                self.lines[row].insert(at, ch);
+                self.cursor.1 += 1;
+            }
+            _ => {}
+        }
+    }
+
+    fn up(&mut self) {
+        if self.cursor.0 > 0 {
+            self.cursor.0 -= 1;
+            self.cursor.1 = self.cursor.1.min(self.lines[self.cursor.0].chars().count());
+        }
+    }
+
+    fn down(&mut self) {
+        if self.cursor.0 + 1 < self.lines.len() {
+            self.cursor.0 += 1;
+            self.cursor.1 = self.cursor.1.min(self.lines[self.cursor.0].chars().count());
+        }
+    }
+}
+
+pub struct Input {
+    buf: Buffer,
+    pub history: History,
+}
+
+impl Input {
+    pub fn new(history: History) -> Self {
+        Self {
+            buf: Buffer::new(),
+            history,
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.buf = Buffer::new();
+    }
+
+    /// Lines of text, plus the box's own two border rows.
+    pub fn height(&self) -> u16 {
+        self.buf.lines.len() as u16 + 2
+    }
+
+    pub fn key(&mut self, key: KeyEvent) -> Action {
+        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        match key.code {
+            KeyCode::Char('c') if ctrl => return Action::Interrupt,
+            KeyCode::Char('d') if ctrl && self.buf.is_empty() => return Action::Eof,
+            KeyCode::Enter if key.modifiers.contains(KeyModifiers::SHIFT) => self.buf.newline(),
+            KeyCode::Enter => {
+                let content = self.buf.content();
+                self.history.push(&content);
+                self.buf = Buffer::new();
+                return Action::Submit(content);
+            }
+            KeyCode::Up if self.buf.lines.len() > 1 && self.buf.cursor.0 > 0 => self.buf.up(),
+            KeyCode::Up => {
+                if let Some(entry) = self.history.prev(&self.buf.content()) {
+                    self.buf = Buffer::from_str(entry);
+                }
+            }
+            KeyCode::Down if self.buf.cursor.0 + 1 < self.buf.lines.len() => self.buf.down(),
+            KeyCode::Down => {
+                if let Some(entry) = self.history.next() {
+                    self.buf = Buffer::from_str(entry);
+                }
+            }
+            code => self.buf.key(code),
+        }
+        Action::Noop
+    }
+
+    /// Draw the box, and put the terminal cursor where the text cursor is.
+    pub fn render(&self, frame: &mut Frame, area: Rect, agent: &str) {
+        let title = Span::styled(
+            format!(" {agent} "),
+            Style::new().add_modifier(Modifier::BOLD | Modifier::DIM),
+        );
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::new().add_modifier(Modifier::DIM))
+            .title(title);
+        let inner = block.inner(area);
+        frame.render_widget(Paragraph::new(self.lines()).block(block), area);
+
+        let (row, col) = self.buf.cursor;
+        frame.set_cursor_position((inner.x + col as u16 + 2, inner.y + row as u16));
+    }
+
+    fn lines(&self) -> Vec<Line<'static>> {
+        self.buf
+            .lines
+            .iter()
+            .enumerate()
+            .map(|(at, line)| {
+                let prompt = match at {
+                    0 => "> ",
+                    _ => "  ",
+                };
+                Line::from(vec![
+                    Span::styled(prompt, Style::new().add_modifier(Modifier::DIM)),
+                    Span::raw(line.clone()),
+                ])
+            })
+            .collect()
+    }
+}
+
+/// Byte offset of a character index, or the end of the string.
+fn byte_of(text: &str, chars: usize) -> usize {
+    text.char_indices()
+        .nth(chars)
+        .map(|(at, _)| at)
+        .unwrap_or(text.len())
+}

--- a/apps/code/src/tui/item.rs
+++ b/apps/code/src/tui/item.rs
@@ -61,6 +61,11 @@ pub enum Item {
     Thinking {
         text: String,
     },
+    /// Something that went wrong, said in the transcript rather than by
+    /// ending the session.
+    Error {
+        text: String,
+    },
     Blank,
 }
 
@@ -148,6 +153,15 @@ impl Item {
                         format!("{PAD}{line}"),
                         Style::new().add_modifier(Modifier::DIM | Modifier::ITALIC),
                     ))
+                })
+                .collect(),
+            Item::Error { text } => text
+                .lines()
+                .map(|line| {
+                    Line::from(vec![
+                        Span::styled("⏺ ", Style::new().fg(RED)),
+                        Span::styled(line.to_owned(), Style::new().fg(RED)),
+                    ])
                 })
                 .collect(),
             Item::Blank => vec![Line::raw("")],

--- a/apps/code/src/tui/item.rs
+++ b/apps/code/src/tui/item.rs
@@ -1,0 +1,273 @@
+//! The transcript, as source rather than as lines.
+//!
+//! An item keeps what it was written from, and renders to lines at a
+//! width asked for at the time. Keeping the rendering instead would make
+//! a resize unanswerable: the terminal reflows its own scrollback, but
+//! not lines something else already wrapped.
+
+use crate::tui::markdown::{self, BRAND, GREEN, PAD, RED, S_DIM, S_SUBTLE, SUBTLE};
+use ratatui::{
+    style::{Modifier, Style},
+    text::{Line, Span},
+};
+
+/// Lines of a tool's output shown before the rest is elided.
+const RESULT_LINES_OK: usize = 5;
+const RESULT_LINES_FAILED: usize = 10;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolStatus {
+    Running,
+    Success,
+    Failure,
+}
+
+/// One logical chunk of the transcript.
+#[derive(Debug, Clone)]
+pub enum Item {
+    /// A markdown line. `marker` gives it the `⏺` that opens a response.
+    Text {
+        md: String,
+        marker: bool,
+    },
+    /// What was typed, echoed into the transcript so scrollback reads as
+    /// a conversation rather than as one side of one.
+    Prompt {
+        text: String,
+    },
+    /// The line a fence opens with, drawn before the block it belongs to
+    /// exists.
+    Border {
+        label: String,
+    },
+    /// A fenced block, kept whole: it is not a block until it closes.
+    Code {
+        code: String,
+    },
+    /// Rows of a table, which wrap as a unit rather than a line at a time.
+    Table {
+        rows: String,
+    },
+    /// One round of tool calls, by label.
+    Tool {
+        labels: Vec<String>,
+        status: ToolStatus,
+    },
+    /// A tool's output, as it came back.
+    Result {
+        output: String,
+        failed: bool,
+    },
+    Thinking {
+        text: String,
+    },
+    Blank,
+}
+
+impl Item {
+    /// Whether this is final. A running tool is not: its marker changes
+    /// when it settles, and a line already in scrollback cannot.
+    pub fn settled(&self) -> bool {
+        !matches!(
+            self,
+            Item::Tool {
+                status: ToolStatus::Running,
+                ..
+            }
+        )
+    }
+
+    /// `frame` drives the spinner on a tool that is still running.
+    pub fn render(&self, width: usize, frame: u64) -> Vec<Line<'static>> {
+        match self {
+            Item::Text { md, marker } => {
+                let mut lines = markdown::lines(md, width);
+                if *marker && !lines.is_empty() {
+                    let first = markdown::unindent(lines.remove(0));
+                    let mut spans = vec![Span::styled("⏺ ", S_DIM)];
+                    spans.extend(first);
+                    lines.insert(0, Line::from(spans));
+                }
+                lines
+            }
+            Item::Prompt { text } => text
+                .lines()
+                .map(|line| {
+                    Line::from(vec![
+                        Span::styled("> ", Style::new().fg(BRAND)),
+                        Span::styled(line.to_owned(), S_DIM),
+                    ])
+                })
+                .collect(),
+            Item::Border { label } => vec![Line::from(vec![
+                Span::raw(PAD),
+                Span::styled(label.clone(), S_SUBTLE),
+            ])],
+            Item::Code { code } => {
+                let mut lines: Vec<Line> = code
+                    .lines()
+                    .map(|line| {
+                        Line::from(vec![
+                            Span::raw(PAD),
+                            Span::styled("│ ", Style::new().fg(SUBTLE)),
+                            Span::raw(line.to_owned()),
+                        ])
+                    })
+                    .collect();
+                lines.push(Line::from(vec![
+                    Span::raw(PAD),
+                    Span::styled("└─", S_SUBTLE),
+                ]));
+                lines
+            }
+            Item::Table { rows } => markdown::lines(rows, width.saturating_sub(PAD.len())),
+            Item::Tool { labels, status } => {
+                let (marker, style) = match status {
+                    ToolStatus::Running => (Span::styled(spinner(frame), S_DIM), S_DIM),
+                    ToolStatus::Success => (
+                        Span::styled("⏺ ", Style::new().fg(GREEN)),
+                        Style::new().add_modifier(Modifier::BOLD | Modifier::DIM),
+                    ),
+                    ToolStatus::Failure => (
+                        Span::styled("⏺ ", Style::new().fg(RED)),
+                        Style::new().add_modifier(Modifier::BOLD | Modifier::DIM),
+                    ),
+                };
+                labels
+                    .iter()
+                    .map(|label| {
+                        Line::from(vec![marker.clone(), Span::styled(label.clone(), style)])
+                    })
+                    .collect()
+            }
+            Item::Result { output, failed } => result_lines(output, *failed, width),
+            Item::Thinking { text } => text
+                .lines()
+                .map(|line| {
+                    Line::from(Span::styled(
+                        format!("{PAD}{line}"),
+                        Style::new().add_modifier(Modifier::DIM | Modifier::ITALIC),
+                    ))
+                })
+                .collect(),
+            Item::Blank => vec![Line::raw("")],
+        }
+    }
+}
+
+/// Whether a tool's output reads as a failure.
+pub fn failed(output: &str) -> bool {
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(output)
+        && let Some(code) = value.get("exit_code").and_then(|c| c.as_i64())
+    {
+        return code != 0;
+    }
+    ["bash failed:", "tool not available:", "invalid arguments:"]
+        .iter()
+        .any(|prefix| output.starts_with(prefix))
+}
+
+/// A tool call named the way the transcript names it: the tool, and for
+/// a shell the command itself, since `Bash` alone says nothing.
+pub fn label(name: &str, args: &str, width: usize) -> String {
+    use heck::ToUpperCamelCase;
+
+    let pascal = name.to_upper_camel_case();
+    if name != "bash" {
+        return pascal;
+    }
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(args) else {
+        return pascal;
+    };
+    let Some(command) = value.get("command").and_then(|c| c.as_str()) else {
+        return pascal;
+    };
+    let first = command.lines().next().unwrap_or(command);
+    let max = width.saturating_sub(8);
+    let shown = match (first.len() > max, first.len() < command.len()) {
+        (true, _) => format!("{}...", &first[..max]),
+        (false, true) => format!("{first}..."),
+        _ => first.to_owned(),
+    };
+    format!("Bash({shown})")
+}
+
+fn result_lines(output: &str, failed: bool, width: usize) -> Vec<Line<'static>> {
+    let max = match failed {
+        true => RESULT_LINES_FAILED,
+        false => RESULT_LINES_OK,
+    };
+    let (shown, total) = elide(output, max);
+    let room = width.saturating_sub(PAD.len() + 2);
+
+    let mut lines = Vec::new();
+    if shown.is_empty() {
+        lines.push(Line::from(vec![
+            Span::raw(PAD),
+            Span::styled("⎿ ", S_SUBTLE),
+            Span::styled("(no output)", S_DIM),
+        ]));
+        return lines;
+    }
+    for (at, line) in shown.iter().enumerate() {
+        let text = match line.len() > room {
+            true => format!("{}...", &line[..room.saturating_sub(3)]),
+            false => line.clone(),
+        };
+        lines.push(match at {
+            0 => Line::from(vec![
+                Span::raw(PAD),
+                Span::styled("⎿ ", S_SUBTLE),
+                Span::styled(text, S_DIM),
+            ]),
+            _ => Line::from(vec![
+                Span::raw(format!("{PAD}  ")),
+                Span::styled(text, S_DIM),
+            ]),
+        });
+    }
+    if total > shown.len() {
+        lines.push(Line::from(vec![
+            Span::raw(format!("{PAD}  ")),
+            Span::styled(format!("… +{} lines", total - shown.len()), S_DIM),
+        ]));
+    }
+    lines
+}
+
+/// The first `max` non-empty lines, and how many there were. A shell
+/// result arrives as JSON, and what is worth showing is the stream that
+/// has something in it.
+fn elide(output: &str, max: usize) -> (Vec<String>, usize) {
+    let text = match serde_json::from_str::<serde_json::Value>(output) {
+        Ok(value) => {
+            let field = |name: &str| {
+                value
+                    .get(name)
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_owned()
+            };
+            let (stdout, stderr) = (field("stdout"), field("stderr"));
+            match value.get("exit_code").and_then(|c| c.as_i64()) {
+                Some(0) | None if !stdout.is_empty() => stdout,
+                Some(_) if !stderr.is_empty() => stderr,
+                Some(_) | None => match stdout.is_empty() {
+                    true => stderr,
+                    false => stdout,
+                },
+            }
+        }
+        Err(_) => output.to_owned(),
+    };
+    let all: Vec<&str> = text.lines().filter(|line| !line.is_empty()).collect();
+    let total = all.len();
+    (all.into_iter().take(max).map(String::from).collect(), total)
+}
+
+/// Braille spinner, trailing space included so it drops in where a
+/// settled `⏺ ` marker would go.
+fn spinner(frame: u64) -> String {
+    const BRAILLE: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+    format!("{} ", BRAILLE[(frame as usize / 2) % BRAILLE.len()])
+}

--- a/apps/code/src/tui/markdown.rs
+++ b/apps/code/src/tui/markdown.rs
@@ -1,0 +1,122 @@
+//! Markdown to ratatui lines, through termimad's wrapper and skin.
+//!
+//! termimad's own styles are not used. It re-exports a crossterm newer
+//! than the one ratatui pins, so a `ContentStyle` cannot cross between
+//! them; the skin is defined here, so what each kind looks like is known
+//! without asking.
+
+use ratatui::{
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+};
+use std::sync::LazyLock;
+use termimad::{CompositeKind, FmtLine, FmtText, MadSkin, minimad::Compound};
+
+/// Left margin of body text, aligning it under the `⏺ ` marker.
+pub const PAD: &str = "  ";
+
+pub const BRAND: Color = Color::Indexed(173);
+pub const GREEN: Color = Color::Indexed(71);
+pub const RED: Color = Color::Indexed(204);
+pub const SUBTLE: Color = Color::Indexed(240);
+
+pub const S_DIM: Style = Style::new().add_modifier(Modifier::DIM);
+pub const S_SUBTLE: Style = Style::new().fg(SUBTLE);
+
+pub static SKIN: LazyLock<MadSkin> = LazyLock::new(|| {
+    use termimad::crossterm::style::{Attribute, Color};
+
+    let mut skin = MadSkin::default_dark();
+    skin.paragraph.left_margin = 2;
+    for (at, color) in [(0, Color::Cyan), (1, Color::Magenta), (2, Color::White)] {
+        skin.headers[at]
+            .compound_style
+            .set_fgbg(color, Color::Reset);
+        skin.headers[at].compound_style.add_attr(Attribute::Bold);
+        skin.headers[at].left_margin = 2;
+    }
+    skin.code_block.left_margin = 4;
+    skin
+});
+
+/// Render `md` at `width`, wrapped and styled.
+pub fn lines(md: &str, width: usize) -> Vec<Line<'static>> {
+    let fmt = FmtText::from(&SKIN, md, Some(width));
+    let mut out = Vec::with_capacity(fmt.lines.len());
+    for line in &fmt.lines {
+        match line {
+            FmtLine::Normal(composite) => {
+                let base = kind_style(composite.kind);
+                let mut spans = vec![Span::raw(" ".repeat(kind_margin(composite.kind)))];
+                for compound in &composite.compounds {
+                    let extra = modifiers(compound);
+                    let style = match extra.is_empty() {
+                        true => base,
+                        false => base.add_modifier(extra),
+                    };
+                    spans.push(Span::styled(compound.src.to_string(), style));
+                }
+                out.push(Line::from(spans));
+            }
+            FmtLine::TableRow(row) => {
+                let mut spans = vec![Span::raw("  │")];
+                for cell in &row.cells {
+                    for compound in &cell.compounds {
+                        spans.push(Span::raw(compound.src.to_string()));
+                    }
+                    spans.push(Span::raw("│"));
+                }
+                out.push(Line::from(spans));
+            }
+            FmtLine::TableRule(rule) => {
+                let total = rule.widths.iter().sum::<usize>() + rule.widths.len() + 1;
+                out.push(Line::raw(format!("  {}", "─".repeat(total))));
+            }
+            FmtLine::HorizontalRule => out.push(Line::raw(format!(
+                "  {}",
+                "─".repeat(width.saturating_sub(2))
+            ))),
+        }
+    }
+    out
+}
+
+/// Drop a line's leading spaces so a marker can take their place.
+pub fn unindent(line: Line<'static>) -> Vec<Span<'static>> {
+    line.spans
+        .into_iter()
+        .skip_while(|span| span.content.chars().all(|c| c == ' '))
+        .collect()
+}
+
+/// Mirrors [`SKIN`] — the header colours it sets, read back.
+fn kind_style(kind: CompositeKind) -> Style {
+    let color = match kind {
+        CompositeKind::Header(1) => Color::Cyan,
+        CompositeKind::Header(2) => Color::Magenta,
+        CompositeKind::Header(_) => Color::White,
+        _ => return Style::default(),
+    };
+    Style::new().fg(color).add_modifier(Modifier::BOLD)
+}
+
+fn kind_margin(kind: CompositeKind) -> usize {
+    match kind {
+        CompositeKind::Code => 4,
+        _ => PAD.len(),
+    }
+}
+
+fn modifiers(compound: &Compound<'_>) -> Modifier {
+    let mut out = Modifier::empty();
+    if compound.bold {
+        out |= Modifier::BOLD;
+    }
+    if compound.italic {
+        out |= Modifier::ITALIC;
+    }
+    if compound.strikeout {
+        out |= Modifier::CROSSED_OUT;
+    }
+    out
+}

--- a/apps/code/src/tui/mod.rs
+++ b/apps/code/src/tui/mod.rs
@@ -1,0 +1,265 @@
+//! The chat loop, inline in the terminal.
+//!
+//! The rule the whole loop follows: **the viewport holds what is
+//! unfinished, scrollback holds what is final.** A settled item is
+//! written once with `insert_before` and belongs to the terminal after
+//! that — its scrolling, its selection, its copy. Nothing here redraws
+//! it, and nothing here can.
+
+use crate::{
+    crab::Crab,
+    tui::{
+        input::{Action, History, Input},
+        item::Item,
+        stream::Transcript,
+    },
+};
+use anyhow::Result;
+use crossterm::{
+    event::{Event as TermEvent, EventStream, KeyEventKind},
+    terminal::{disable_raw_mode, enable_raw_mode},
+};
+use futures_util::StreamExt;
+use proto::stream_event::Event as Chunk;
+use ratatui::{
+    Frame, Terminal, TerminalOptions, Viewport,
+    backend::CrosstermBackend,
+    layout::{Constraint, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Paragraph, Widget},
+};
+use std::{io::Stdout, time::Duration};
+use tokio::sync::mpsc;
+
+mod input;
+mod item;
+mod markdown;
+mod stream;
+
+/// Rows the viewport keeps for what has not settled: the input box, the
+/// status line, and the block currently streaming. ratatui cannot resize
+/// an inline viewport after it is built, so this is a ceiling rather than
+/// a preference — a taller input scrolls inside it.
+const VIEWPORT: u16 = 8;
+
+/// How often the spinner advances while a tool runs.
+const TICK: Duration = Duration::from_millis(80);
+
+type Screen = Terminal<CrosstermBackend<Stdout>>;
+
+pub async fn run(crab: Crab) -> Result<()> {
+    enable_raw_mode()?;
+    // A panic past this point would otherwise leave the terminal raw and
+    // the shell unusable, so put it back before the message is printed.
+    let hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = disable_raw_mode();
+        hook(info);
+    }));
+
+    let terminal = Terminal::with_options(
+        CrosstermBackend::new(std::io::stdout()),
+        TerminalOptions {
+            viewport: Viewport::Inline(VIEWPORT),
+        },
+    );
+    let mut terminal = match terminal {
+        Ok(terminal) => terminal,
+        Err(e) => {
+            let _ = disable_raw_mode();
+            return Err(e.into());
+        }
+    };
+
+    let mut app = App::new(crab, terminal.size()?.width as usize);
+    let result = app.run(&mut terminal).await;
+
+    disable_raw_mode()?;
+    // Leave the viewport behind rather than on top of the prompt.
+    terminal.clear()?;
+    app.input.history.save(&history_path());
+    result
+}
+
+fn history_path() -> std::path::PathBuf {
+    crabup::dirs::CONFIG_DIR.join("code/history")
+}
+
+struct App {
+    crab: Crab,
+    transcript: Transcript,
+    input: Input,
+    /// The turn in flight, if there is one. Dropping it walks away.
+    turn: Option<mpsc::UnboundedReceiver<Result<Chunk>>>,
+    frame: u64,
+}
+
+impl App {
+    fn new(crab: Crab, width: usize) -> Self {
+        Self {
+            transcript: Transcript::new(width),
+            input: Input::new(History::load(&history_path())),
+            turn: None,
+            frame: 0,
+            crab,
+        }
+    }
+
+    async fn run(&mut self, terminal: &mut Screen) -> Result<()> {
+        let mut keys = EventStream::new();
+        let mut tick = tokio::time::interval(TICK);
+
+        loop {
+            self.commit(terminal)?;
+            terminal.draw(|frame| self.view(frame))?;
+
+            tokio::select! {
+                Some(event) = keys.next() => {
+                    match event? {
+                        TermEvent::Key(key) if key.kind == KeyEventKind::Press => {
+                            if self.key(key) {
+                                return Ok(());
+                            }
+                        }
+                        TermEvent::Resize(width, _) => self.transcript.set_width(width as usize),
+                        _ => {}
+                    }
+                }
+                Some(event) = turn(&mut self.turn) => self.chunk(event?),
+                _ = tick.tick() => self.frame += 1,
+            }
+        }
+    }
+
+    /// `true` to leave.
+    fn key(&mut self, key: crossterm::event::KeyEvent) -> bool {
+        match self.input.key(key) {
+            Action::Submit(prompt) if !prompt.trim().is_empty() => {
+                self.transcript.push(Item::Prompt {
+                    text: prompt.clone(),
+                });
+                self.transcript.push(Item::Blank);
+                self.transcript.start();
+                self.turn = Some(self.crab.spawn_turn(&prompt));
+            }
+            Action::Submit(_) => {}
+            // A turn walks away; an idle Ctrl+C only clears the line.
+            Action::Interrupt => match self.turn.take() {
+                Some(_) => self.transcript.finish(),
+                None => self.input.clear(),
+            },
+            Action::Eof => return true,
+            Action::Noop => {}
+        }
+        false
+    }
+
+    fn chunk(&mut self, chunk: Chunk) {
+        match chunk {
+            Chunk::Chunk(text) => self.transcript.push_text(&text.content),
+            Chunk::Thinking(text) => self.transcript.push_thinking(&text.content),
+            Chunk::ToolStart(start) => {
+                let calls: Vec<(String, String)> = start
+                    .calls
+                    .iter()
+                    .map(|call| (call.name.clone(), call.arguments.clone()))
+                    .collect();
+                self.transcript.push_tool_start(&calls);
+            }
+            Chunk::ToolResult(result) => self.transcript.push_tool_result(&result.output),
+            Chunk::ToolsComplete(_) => self.transcript.push_tool_done(),
+            Chunk::End(end) => {
+                if !end.error.is_empty() {
+                    self.transcript.push_text(&format!("\n{}\n", end.error));
+                }
+                self.transcript.finish();
+                self.turn = None;
+            }
+            _ => {}
+        }
+    }
+
+    /// Hand everything final to the terminal, one item at a time.
+    fn commit(&mut self, terminal: &mut Screen) -> Result<()> {
+        let width = terminal.size()?.width as usize;
+        let mut lines = Vec::new();
+        for item in self.transcript.settled() {
+            lines.extend(item.render(width, self.frame));
+        }
+        if lines.is_empty() {
+            return Ok(());
+        }
+        terminal.insert_before(lines.len() as u16, |buf| {
+            Paragraph::new(lines).render(buf.area, buf);
+        })?;
+        Ok(())
+    }
+
+    fn view(&self, frame: &mut Frame) {
+        let area = frame.area();
+        let input_height = self.input.height().min(area.height.saturating_sub(1));
+        let [live, box_area, status] = Layout::vertical([
+            Constraint::Min(0),
+            Constraint::Length(input_height),
+            Constraint::Length(1),
+        ])
+        .areas(area);
+
+        self.live(frame, live);
+        self.input.render(frame, box_area, "crab");
+        frame.render_widget(Paragraph::new(self.status()), status);
+    }
+
+    /// What is still in flight, anchored to the bottom so it sits against
+    /// the input box and the blank room is up against the scrollback.
+    fn live(&self, frame: &mut Frame, area: Rect) {
+        let width = area.width as usize;
+        let mut lines: Vec<Line> = self
+            .transcript
+            .live()
+            .iter()
+            .flat_map(|item| item.render(width, self.frame))
+            .collect();
+        if let Some(current) = self.transcript.current() {
+            lines.push(current);
+        }
+        let height = area.height as usize;
+        if lines.len() > height {
+            lines.drain(..lines.len() - height);
+        }
+        let top = area.height.saturating_sub(lines.len() as u16);
+        frame.render_widget(
+            Paragraph::new(lines),
+            Rect {
+                y: area.y + top,
+                height: area.height - top,
+                ..area
+            },
+        );
+    }
+
+    fn status(&self) -> Line<'static> {
+        let dim = Style::new().add_modifier(Modifier::DIM);
+        let state = match (self.turn.is_some(), self.transcript.waiting) {
+            (true, true) => "thinking",
+            (true, false) => "working",
+            _ => "ready",
+        };
+        Line::from(vec![
+            Span::styled(format!("  {state}"), dim),
+            Span::styled(
+                format!("  ·  {}  ·  ctrl+d to exit", self.crab.root.display()),
+                dim,
+            ),
+        ])
+    }
+}
+
+/// The turn's next event, or never when there is no turn.
+async fn turn(turn: &mut Option<mpsc::UnboundedReceiver<Result<Chunk>>>) -> Option<Result<Chunk>> {
+    match turn {
+        Some(events) => events.recv().await,
+        None => std::future::pending().await,
+    }
+}

--- a/apps/code/src/tui/mod.rs
+++ b/apps/code/src/tui/mod.rs
@@ -178,9 +178,18 @@ impl App {
                 self.turn = Some(self.crab.spawn_turn(&line));
             }
             Action::Submit(_) => {}
-            // A turn walks away; an idle Ctrl+C only clears the line.
+            // A turn is stopped where it runs; an idle Ctrl+C only clears
+            // the line.
             Action::Interrupt => match self.turn.take() {
-                Some(_) => self.transcript.finish(),
+                Some(_) => {
+                    if let Err(e) = self.crab.cancel().await {
+                        self.transcript.push(Item::Error {
+                            text: e.to_string(),
+                        });
+                    }
+                    self.transcript.finish();
+                    self.transcript.push(Item::Blank);
+                }
                 None => self.input.clear(),
             },
             Action::Eof => return Ok(true),

--- a/apps/code/src/tui/mod.rs
+++ b/apps/code/src/tui/mod.rs
@@ -9,6 +9,7 @@
 use crate::{
     crab::Crab,
     tui::{
+        command::{Command, HELP},
         input::{Action, History, Input},
         item::Item,
         stream::Transcript,
@@ -16,7 +17,7 @@ use crate::{
 };
 use anyhow::Result;
 use crossterm::{
-    event::{Event as TermEvent, EventStream, KeyEventKind},
+    event::{Event as TermEvent, EventStream, KeyEvent, KeyEventKind},
     terminal::{disable_raw_mode, enable_raw_mode},
 };
 use futures_util::StreamExt;
@@ -32,9 +33,11 @@ use ratatui::{
 use std::{io::Stdout, time::Duration};
 use tokio::sync::mpsc;
 
+mod command;
 mod input;
 mod item;
 mod markdown;
+mod replay;
 mod stream;
 
 /// Rows the viewport keeps for what has not settled: the input box, the
@@ -86,6 +89,14 @@ fn history_path() -> std::path::PathBuf {
     crabup::dirs::CONFIG_DIR.join("code/history")
 }
 
+/// What the loop woke for. Read out of the select rather than handled
+/// inside it, so a handler can borrow the whole app.
+enum Wake {
+    Term(TermEvent),
+    Turn(Result<Chunk>),
+    Tick,
+}
+
 struct App {
     crab: Crab,
     transcript: Transcript,
@@ -107,6 +118,7 @@ impl App {
     }
 
     async fn run(&mut self, terminal: &mut Screen) -> Result<()> {
+        self.replay(terminal).await?;
         let mut keys = EventStream::new();
         let mut tick = tokio::time::interval(TICK);
 
@@ -114,34 +126,71 @@ impl App {
             self.commit(terminal)?;
             terminal.draw(|frame| self.view(frame))?;
 
-            tokio::select! {
-                Some(event) = keys.next() => {
-                    match event? {
-                        TermEvent::Key(key) if key.kind == KeyEventKind::Press => {
-                            if self.key(key) {
-                                return Ok(());
-                            }
-                        }
-                        TermEvent::Resize(width, _) => self.transcript.set_width(width as usize),
-                        _ => {}
+            let wake = tokio::select! {
+                Some(event) = keys.next() => Wake::Term(event?),
+                Some(event) = turn(&mut self.turn) => Wake::Turn(event),
+                _ = tick.tick() => Wake::Tick,
+            };
+
+            match wake {
+                Wake::Term(TermEvent::Key(key)) if key.kind == KeyEventKind::Press => {
+                    if self.key(key).await? {
+                        return Ok(());
                     }
                 }
-                Some(event) = turn(&mut self.turn) => self.chunk(event?),
-                _ = tick.tick() => self.frame += 1,
+                Wake::Term(TermEvent::Resize(width, _)) => {
+                    self.transcript.set_width(width as usize)
+                }
+                Wake::Term(_) => {}
+                Wake::Turn(Ok(chunk)) => self.chunk(chunk),
+                Wake::Turn(Err(e)) => self.fail(e.to_string()),
+                Wake::Tick => self.frame += 1,
             }
         }
     }
 
+    /// Put the stored session back on screen, so resuming shows the
+    /// conversation the model is already holding.
+    async fn replay(&mut self, terminal: &mut Screen) -> Result<()> {
+        let history = self.crab.history().await?;
+        if history.is_empty() {
+            return Ok(());
+        }
+        let width = terminal.size()?.width as usize;
+        let mut lines: Vec<Line> = replay::items(&history)
+            .iter()
+            .flat_map(|item| item.render(width, 0))
+            .collect();
+
+        if lines.len() > replay::MAX_ROWS {
+            let dropped = lines.len() - replay::MAX_ROWS;
+            lines.drain(..dropped);
+            lines.insert(
+                0,
+                Line::from(Span::styled(
+                    format!("  … {dropped} earlier lines not replayed"),
+                    Style::new().add_modifier(Modifier::DIM),
+                )),
+            );
+        }
+        lines.push(Line::raw(""));
+        terminal.insert_before(lines.len() as u16, |buf| {
+            Paragraph::new(lines).render(buf.area, buf);
+        })?;
+        Ok(())
+    }
+
     /// `true` to leave.
-    fn key(&mut self, key: crossterm::event::KeyEvent) -> bool {
+    async fn key(&mut self, key: KeyEvent) -> Result<bool> {
         match self.input.key(key) {
-            Action::Submit(prompt) if !prompt.trim().is_empty() => {
-                self.transcript.push(Item::Prompt {
-                    text: prompt.clone(),
-                });
+            Action::Submit(line) if !line.trim().is_empty() => {
+                if let Some(command) = Command::parse(&line) {
+                    return self.command(command).await;
+                }
+                self.transcript.push(Item::Prompt { text: line.clone() });
                 self.transcript.push(Item::Blank);
                 self.transcript.start();
-                self.turn = Some(self.crab.spawn_turn(&prompt));
+                self.turn = Some(self.crab.spawn_turn(&line));
             }
             Action::Submit(_) => {}
             // A turn walks away; an idle Ctrl+C only clears the line.
@@ -149,10 +198,47 @@ impl App {
                 Some(_) => self.transcript.finish(),
                 None => self.input.clear(),
             },
-            Action::Eof => return true,
+            Action::Eof => return Ok(true),
             Action::Noop => {}
         }
-        false
+        Ok(false)
+    }
+
+    async fn command(&mut self, command: Command) -> Result<bool> {
+        match command {
+            Command::Exit => return Ok(true),
+            Command::Help => {
+                for (name, about) in HELP {
+                    self.transcript.push(Item::Text {
+                        md: format!("`{name}` — {about}"),
+                        marker: false,
+                    });
+                }
+                self.transcript.push(Item::Blank);
+            }
+            Command::Reconnect => {
+                // A turn against the old engine has nowhere to land.
+                self.turn = None;
+                self.transcript.finish();
+                match self.crab.reconnect().await {
+                    Ok(()) => self.transcript.push(Item::Text {
+                        md: "reconnected".to_owned(),
+                        marker: true,
+                    }),
+                    Err(e) => self.transcript.push(Item::Error {
+                        text: e.to_string(),
+                    }),
+                }
+                self.transcript.push(Item::Blank);
+            }
+            Command::Unknown(name) => {
+                self.transcript.push(Item::Error {
+                    text: format!("no command /{name} — /help lists them"),
+                });
+                self.transcript.push(Item::Blank);
+            }
+        }
+        Ok(false)
     }
 
     fn chunk(&mut self, chunk: Chunk) {
@@ -169,15 +255,23 @@ impl App {
             }
             Chunk::ToolResult(result) => self.transcript.push_tool_result(&result.output),
             Chunk::ToolsComplete(_) => self.transcript.push_tool_done(),
-            Chunk::End(end) => {
-                if !end.error.is_empty() {
-                    self.transcript.push_text(&format!("\n{}\n", end.error));
-                }
+            Chunk::End(end) if !end.error.is_empty() => self.fail(end.error),
+            Chunk::End(_) => {
                 self.transcript.finish();
                 self.turn = None;
             }
             _ => {}
         }
+    }
+
+    /// Say what went wrong and stay. A failed turn is not a reason to
+    /// take the session down — the endpoint it could not reach is often
+    /// back by the next one, and `/reconnect` is there for when it is not.
+    fn fail(&mut self, error: String) {
+        self.transcript.finish();
+        self.transcript.push(Item::Error { text: error });
+        self.transcript.push(Item::Blank);
+        self.turn = None;
     }
 
     /// Hand everything final to the terminal, one item at a time.
@@ -249,7 +343,10 @@ impl App {
         Line::from(vec![
             Span::styled(format!("  {state}"), dim),
             Span::styled(
-                format!("  ·  {}  ·  ctrl+d to exit", self.crab.root.display()),
+                format!(
+                    "  ·  {}  ·  /help  ·  ctrl+d to exit",
+                    self.crab.root.display()
+                ),
                 dim,
             ),
         ])

--- a/apps/code/src/tui/mod.rs
+++ b/apps/code/src/tui/mod.rs
@@ -8,6 +8,7 @@
 
 use crate::{
     crab::Crab,
+    term,
     tui::{
         command::{Command, HELP},
         input::{Action, History, Input},
@@ -16,14 +17,11 @@ use crate::{
     },
 };
 use anyhow::Result;
-use crossterm::{
-    event::{Event as TermEvent, EventStream, KeyEvent, KeyEventKind},
-    terminal::{disable_raw_mode, enable_raw_mode},
-};
+use crossterm::event::{Event as TermEvent, EventStream, KeyEvent, KeyEventKind};
 use futures_util::StreamExt;
 use proto::stream_event::Event as Chunk;
 use ratatui::{
-    Frame, Terminal, TerminalOptions, Viewport,
+    Frame, Terminal,
     backend::CrosstermBackend,
     layout::{Constraint, Layout, Rect},
     style::{Modifier, Style},
@@ -52,35 +50,9 @@ const TICK: Duration = Duration::from_millis(80);
 type Screen = Terminal<CrosstermBackend<Stdout>>;
 
 pub async fn run(crab: Crab) -> Result<()> {
-    enable_raw_mode()?;
-    // A panic past this point would otherwise leave the terminal raw and
-    // the shell unusable, so put it back before the message is printed.
-    let hook = std::panic::take_hook();
-    std::panic::set_hook(Box::new(move |info| {
-        let _ = disable_raw_mode();
-        hook(info);
-    }));
-
-    let terminal = Terminal::with_options(
-        CrosstermBackend::new(std::io::stdout()),
-        TerminalOptions {
-            viewport: Viewport::Inline(VIEWPORT),
-        },
-    );
-    let mut terminal = match terminal {
-        Ok(terminal) => terminal,
-        Err(e) => {
-            let _ = disable_raw_mode();
-            return Err(e.into());
-        }
-    };
-
+    let mut terminal = term::Inline::open(VIEWPORT)?;
     let mut app = App::new(crab, terminal.size()?.width as usize);
     let result = app.run(&mut terminal).await;
-
-    disable_raw_mode()?;
-    // Leave the viewport behind rather than on top of the prompt.
-    terminal.clear()?;
     app.input.history.save(&history_path());
     result
 }

--- a/apps/code/src/tui/mod.rs
+++ b/apps/code/src/tui/mod.rs
@@ -103,6 +103,13 @@ struct App {
     input: Input,
     /// The turn in flight, if there is one. Dropping it walks away.
     turn: Option<mpsc::UnboundedReceiver<Result<Chunk>>>,
+    /// Prompt tokens the last call reported. Shown rather than acted on:
+    /// nothing here knows the model's window, so what to do about the
+    /// number is the developer's call.
+    tokens: Option<u32>,
+    /// Set when a turn ends over the window, acted on by the loop —
+    /// summarizing is a round trip and the event handler is not async.
+    compact_due: bool,
     frame: u64,
 }
 
@@ -112,6 +119,8 @@ impl App {
             transcript: Transcript::new(width),
             input: Input::new(History::load(&history_path())),
             turn: None,
+            tokens: None,
+            compact_due: false,
             frame: 0,
             crab,
         }
@@ -145,6 +154,10 @@ impl App {
                 Wake::Turn(Ok(chunk)) => self.chunk(chunk),
                 Wake::Turn(Err(e)) => self.fail(e.to_string()),
                 Wake::Tick => self.frame += 1,
+            }
+
+            if std::mem::take(&mut self.compact_due) {
+                self.compact(true).await;
             }
         }
     }
@@ -231,6 +244,7 @@ impl App {
                 }
                 self.transcript.push(Item::Blank);
             }
+            Command::Compact => self.compact(false).await,
             Command::Unknown(name) => {
                 self.transcript.push(Item::Error {
                     text: format!("no command /{name} — /help lists them"),
@@ -253,15 +267,53 @@ impl App {
                     .collect();
                 self.transcript.push_tool_start(&calls);
             }
+            Chunk::ContextUsage(context) => {
+                self.tokens = context.usage.map(|usage| usage.prompt_tokens)
+            }
             Chunk::ToolResult(result) => self.transcript.push_tool_result(&result.output),
             Chunk::ToolsComplete(_) => self.transcript.push_tool_done(),
             Chunk::End(end) if !end.error.is_empty() => self.fail(end.error),
             Chunk::End(_) => {
                 self.transcript.finish();
                 self.turn = None;
+                self.compact_due = self.tokens.is_some_and(|used| self.crab.overflows(used));
             }
             _ => {}
         }
+    }
+
+    /// Summarize the conversation and work from the summary.
+    ///
+    /// `automatic` when the last turn left no room for the next one, in
+    /// which case it says so — a conversation that rewrites itself
+    /// without a word looks like one that lost its memory.
+    async fn compact(&mut self, automatic: bool) {
+        self.turn = None;
+        self.transcript.finish();
+        if automatic {
+            self.transcript.push(Item::Text {
+                md: "*the next turn would not fit — summarizing*".to_owned(),
+                marker: false,
+            });
+        }
+        match self.crab.compact().await {
+            Ok(summary) => {
+                self.transcript.push(Item::Text {
+                    md: summary,
+                    marker: true,
+                });
+                self.transcript.push(Item::Blank);
+                self.transcript.push(Item::Text {
+                    md: "*the conversation above is now this summary*".to_owned(),
+                    marker: false,
+                });
+                self.tokens = None;
+            }
+            Err(e) => self.transcript.push(Item::Error {
+                text: e.to_string(),
+            }),
+        }
+        self.transcript.push(Item::Blank);
     }
 
     /// Say what went wrong and stay. A failed turn is not a reason to
@@ -340,15 +392,19 @@ impl App {
             (true, false) => "working",
             _ => "ready",
         };
+        let context = match (self.tokens, self.crab.config.context_window) {
+            (Some(tokens), Some(window)) => format!(
+                "  ·  {:.1}k / {:.0}k",
+                tokens as f64 / 1000.0,
+                window as f64 / 1000.0
+            ),
+            (Some(tokens), None) => format!("  ·  {:.1}k context", tokens as f64 / 1000.0),
+            _ => String::new(),
+        };
         Line::from(vec![
             Span::styled(format!("  {state}"), dim),
-            Span::styled(
-                format!(
-                    "  ·  {}  ·  /help  ·  ctrl+d to exit",
-                    self.crab.root.display()
-                ),
-                dim,
-            ),
+            Span::styled(context, dim),
+            Span::styled(format!("  ·  {}  ·  /help", self.crab.root.display()), dim),
         ])
     }
 }

--- a/apps/code/src/tui/replay.rs
+++ b/apps/code/src/tui/replay.rs
@@ -1,0 +1,80 @@
+//! A stored session, back into the transcript.
+//!
+//! Resuming without this leaves the model holding a conversation the
+//! person cannot see. What goes to scrollback is built from the same
+//! items a live turn produces, so a replayed transcript and a streamed
+//! one are the same thing rendered twice.
+
+use crate::tui::item::{self, Item, ToolStatus};
+use crabllm_core::Role;
+use store::HistoryEntry;
+
+/// Rows of history replayed at most.
+///
+/// This is rebuilding the terminal's own scrollback rather than an
+/// internal buffer, so replaying more rows than a terminal keeps is work
+/// nobody can scroll back to. Codex caps this per terminal and falls back
+/// to a thousand rows for one it cannot identify; that fallback is what
+/// this is.
+pub const MAX_ROWS: usize = 1000;
+
+/// The transcript a stored history reads as, oldest first.
+pub fn items(history: &[HistoryEntry]) -> Vec<Item> {
+    let mut out: Vec<Item> = Vec::new();
+    for entry in history {
+        // A tool result arrives as a user message, so it is checked before
+        // the role is.
+        if !entry.tool_call_id().is_empty() {
+            let output = entry.text().to_owned();
+            let failed = item::failed(&output);
+            if failed {
+                settle(&mut out, ToolStatus::Failure);
+            }
+            out.push(Item::Result { output, failed });
+            out.push(Item::Blank);
+            continue;
+        }
+        match entry.role() {
+            Role::System => {}
+            Role::User if entry.text().is_empty() => {}
+            Role::User => {
+                out.push(Item::Prompt {
+                    text: entry.text().to_owned(),
+                });
+                out.push(Item::Blank);
+            }
+            _ => {
+                if !entry.text().is_empty() {
+                    out.push(Item::Text {
+                        md: entry.text().to_owned(),
+                        marker: true,
+                    });
+                }
+                let labels: Vec<String> = entry
+                    .tool_calls()
+                    .iter()
+                    .map(|call| item::label(&call.function.name, &call.function.arguments, 80))
+                    .collect();
+                if !labels.is_empty() {
+                    out.push(Item::Blank);
+                    out.push(Item::Tool {
+                        labels,
+                        status: ToolStatus::Success,
+                    });
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Mark the tool a result belongs to, which is the most recent one.
+fn settle(items: &mut [Item], status: ToolStatus) {
+    if let Some(Item::Tool { status: held, .. }) = items
+        .iter_mut()
+        .rev()
+        .find(|item| matches!(item, Item::Tool { .. }))
+    {
+        *held = status;
+    }
+}

--- a/apps/code/src/tui/stream.rs
+++ b/apps/code/src/tui/stream.rs
@@ -1,0 +1,301 @@
+//! The transcript as it arrives: chunks in, items out.
+//!
+//! A line is the unit. Text is held until its newline, a fence until it
+//! closes, a tool until it settles — and only then does it become an
+//! item, because an item is what goes to scrollback and scrollback
+//! cannot be edited afterwards.
+
+use crate::tui::{
+    item::{self, Item, ToolStatus},
+    markdown::{PAD, S_DIM},
+};
+use ratatui::text::{Line, Span};
+
+#[derive(Default)]
+enum State {
+    #[default]
+    Normal,
+    Code {
+        code: String,
+    },
+    Table {
+        rows: String,
+    },
+    Thinking,
+}
+
+pub struct Transcript {
+    pub items: Vec<Item>,
+    /// True while a turn is in flight with nothing shown for it yet.
+    pub waiting: bool,
+    /// How many items have reached scrollback.
+    committed: usize,
+    /// The line being typed into by the model.
+    line: String,
+    state: State,
+    /// Whether the next rendered line opens a response and takes the `⏺`.
+    marker: bool,
+    started: bool,
+    after_tool: bool,
+    thinking: String,
+    tool_failed: bool,
+    width: usize,
+}
+
+impl Transcript {
+    pub fn new(width: usize) -> Self {
+        Self {
+            items: Vec::new(),
+            waiting: false,
+            committed: 0,
+            line: String::new(),
+            state: State::default(),
+            marker: false,
+            started: false,
+            after_tool: false,
+            thinking: String::new(),
+            tool_failed: false,
+            width,
+        }
+    }
+
+    pub fn set_width(&mut self, width: usize) {
+        self.width = width;
+    }
+
+    /// Items that became final since the last call, in order.
+    pub fn settled(&mut self) -> &[Item] {
+        let from = self.committed;
+        while self
+            .items
+            .get(self.committed)
+            .is_some_and(|item| item.settled())
+        {
+            self.committed += 1;
+        }
+        &self.items[from..self.committed]
+    }
+
+    /// Items still in flight, which the viewport draws until they settle.
+    pub fn live(&self) -> &[Item] {
+        &self.items[self.committed..]
+    }
+
+    /// The partial line, drawn under the live items.
+    pub fn current(&self) -> Option<Line<'static>> {
+        if self.line.is_empty() {
+            return None;
+        }
+        let prefix = match self.marker || !self.started {
+            true => Span::styled("⏺ ", S_DIM),
+            false => Span::raw(PAD),
+        };
+        Some(Line::from(vec![prefix, Span::raw(self.line.clone())]))
+    }
+
+    /// A turn has been sent and nothing has come back yet.
+    pub fn start(&mut self) {
+        self.waiting = true;
+        self.started = false;
+        self.marker = false;
+        self.after_tool = false;
+        self.tool_failed = false;
+    }
+
+    pub fn push_text(&mut self, chunk: &str) {
+        if chunk.is_empty() {
+            return;
+        }
+        self.waiting = false;
+        if matches!(self.state, State::Thinking) {
+            self.flush_thinking();
+        }
+        if !self.started {
+            self.started = true;
+            self.marker = true;
+        }
+        if self.after_tool {
+            self.after_tool = false;
+            self.marker = true;
+        }
+
+        for ch in chunk.chars() {
+            if ch != '\n' {
+                self.line.push(ch);
+                continue;
+            }
+            let line = std::mem::take(&mut self.line);
+            let had_content = !line.is_empty();
+            self.line(&line);
+            // A blank line at the start of a response must not eat the
+            // marker the first real one is owed.
+            if had_content {
+                self.marker = false;
+            }
+        }
+    }
+
+    pub fn push_thinking(&mut self, chunk: &str) {
+        if chunk.is_empty() {
+            return;
+        }
+        self.waiting = false;
+        self.state = State::Thinking;
+        self.thinking.push_str(chunk);
+    }
+
+    pub fn push_tool_start(&mut self, calls: &[(String, String)]) {
+        self.flush_thinking();
+        self.flush_line();
+        self.waiting = false;
+        self.tool_failed = false;
+        self.items.push(Item::Blank);
+        self.items.push(Item::Tool {
+            labels: calls
+                .iter()
+                .map(|(name, args)| item::label(name, args, self.width))
+                .collect(),
+            status: ToolStatus::Running,
+        });
+    }
+
+    pub fn push_tool_result(&mut self, output: &str) {
+        let failed = item::failed(output);
+        self.tool_failed |= failed;
+        self.items.push(Item::Result {
+            output: output.to_owned(),
+            failed,
+        });
+        self.items.push(Item::Blank);
+    }
+
+    /// Settle the running tool, which is what lets everything queued
+    /// behind it reach scrollback.
+    pub fn push_tool_done(&mut self) {
+        let status = match self.tool_failed {
+            true => ToolStatus::Failure,
+            false => ToolStatus::Success,
+        };
+        for item in self.items.iter_mut().rev() {
+            if let Item::Tool { status: held, .. } = item
+                && *held == ToolStatus::Running
+            {
+                *held = status;
+                break;
+            }
+        }
+        self.after_tool = true;
+    }
+
+    /// End of turn: nothing more is coming, so nothing stays in flight.
+    pub fn finish(&mut self) {
+        self.push_tool_done();
+        self.flush_thinking();
+        self.flush_line();
+        self.waiting = false;
+        self.after_tool = false;
+    }
+
+    /// Push a line the caller wrote rather than the model — a prompt
+    /// echo, an error, a notice.
+    pub fn push(&mut self, item: Item) {
+        self.items.push(item);
+    }
+
+    // ── Internal ────────────────────────────────────────────────
+
+    fn line(&mut self, line: &str) {
+        match &mut self.state {
+            State::Code { code } => match line.starts_with("```") {
+                true => {
+                    let code = std::mem::take(code);
+                    self.items.push(Item::Code { code });
+                    self.state = State::Normal;
+                }
+                false => {
+                    code.push_str(line);
+                    code.push('\n');
+                }
+            },
+            State::Table { rows } => match line.starts_with('|') {
+                true => {
+                    rows.push_str(line);
+                    rows.push('\n');
+                }
+                false => {
+                    self.flush_table();
+                    self.line(line);
+                }
+            },
+            State::Normal | State::Thinking => {
+                if let Some(rest) = line.strip_prefix("```") {
+                    self.open_code(rest.trim());
+                } else if line.starts_with('|') {
+                    self.state = State::Table {
+                        rows: format!("{line}\n"),
+                    };
+                } else if line.is_empty() {
+                    self.items.push(Item::Blank);
+                } else {
+                    self.items.push(Item::Text {
+                        md: line.to_owned(),
+                        marker: self.marker,
+                    });
+                }
+            }
+        }
+    }
+
+    /// The opening border is its own item: it is known the moment the
+    /// fence opens, where the block itself is not known until it closes.
+    fn open_code(&mut self, lang: &str) {
+        let label = match lang.is_empty() {
+            true => "┌─".to_owned(),
+            false => format!("┌ {lang} ─"),
+        };
+        self.items.push(Item::Border { label });
+        self.marker = false;
+        self.state = State::Code {
+            code: String::new(),
+        };
+    }
+
+    fn flush_table(&mut self) {
+        if let State::Table { rows } = &mut self.state {
+            let rows = std::mem::take(rows);
+            self.items.push(Item::Table { rows });
+        }
+        self.state = State::Normal;
+    }
+
+    /// Whatever is half-written becomes an item, because the thing that
+    /// would have completed it is not coming.
+    fn flush_line(&mut self) {
+        if self.line.is_empty() {
+            return;
+        }
+        let line = std::mem::take(&mut self.line);
+        match &mut self.state {
+            State::Code { code } => {
+                let code = format!("{code}{line}");
+                self.items.push(Item::Code { code });
+                self.state = State::Normal;
+            }
+            _ => self.items.push(Item::Text {
+                md: line,
+                marker: self.marker,
+            }),
+        }
+        self.marker = false;
+    }
+
+    fn flush_thinking(&mut self) {
+        if !self.thinking.is_empty() {
+            let text = std::mem::take(&mut self.thinking);
+            self.items.push(Item::Thinking { text });
+        }
+        if matches!(self.state, State::Thinking) {
+            self.state = State::Normal;
+        }
+    }
+}

--- a/apps/code/src/tui/stream.rs
+++ b/apps/code/src/tui/stream.rs
@@ -25,7 +25,7 @@ enum State {
 }
 
 pub struct Transcript {
-    pub items: Vec<Item>,
+    items: Vec<Item>,
     /// True while a turn is in flight with nothing shown for it yet.
     pub waiting: bool,
     /// How many items have reached scrollback.

--- a/apps/crabup/src/cmd/mod.rs
+++ b/apps/crabup/src/cmd/mod.rs
@@ -16,6 +16,7 @@ pub mod list;
 pub const CRATES: &[(&str, &str)] = &[
     ("crabtalk-agent", "crabtalkd"),
     ("crabtalk-cli", "crabtalk"),
+    ("crabtalk-code", "crab"),
 ];
 
 #[derive(clap::Parser, Debug)]

--- a/apps/crabup/src/dirs.rs
+++ b/apps/crabup/src/dirs.rs
@@ -42,5 +42,11 @@ pub static HARNESSES_DIR: LazyLock<PathBuf> = LazyLock::new(|| CONFIG_DIR.join("
 /// Cache root (`~/.crabtalk/cache/`), one subdirectory per thing that caches.
 pub static CACHE_DIR: LazyLock<PathBuf> = LazyLock::new(|| CONFIG_DIR.join("cache"));
 
-/// The store file (`~/.crabtalk/store.crmem`).
-pub static STORE_FILE: LazyLock<PathBuf> = LazyLock::new(|| CONFIG_DIR.join("store.crmem"));
+/// Where stores live (`~/.crabtalk/store/`), one file per product.
+pub static STORE_DIR: LazyLock<PathBuf> = LazyLock::new(|| CONFIG_DIR.join("store"));
+
+/// The daemon's store (`~/.crabtalk/store/crabtalk.crmem`).
+pub static STORE_FILE: LazyLock<PathBuf> = LazyLock::new(|| STORE_DIR.join("crabtalk.crmem"));
+
+/// Where the daemon's store was before it had a directory to share.
+pub static LEGACY_STORE_FILE: LazyLock<PathBuf> = LazyLock::new(|| CONFIG_DIR.join("store.crmem"));

--- a/crates/berm/README.md
+++ b/crates/berm/README.md
@@ -2,8 +2,8 @@
 
 Crabtalk's side of [berm](https://github.com/crabtalk/berm): the harness hook and every system
 harness Crabtalk serves — `crabtalk.fs`, `crabtalk.exec`, `crabtalk.http.fetch`,
-one runtime door per operation, and `berm.call`, which resolves the name one
-harness reaches another by. berm serves none of its own.
+one runtime capability per operation, and `berm.call`, which resolves the name
+one harness reaches another by. berm serves none of its own.
 
 berm itself has no crabtalk crate in its dependency list and cannot grow one
 without `src/lib.rs` here moving — which is what makes "berm is embeddable

--- a/crates/store/src/agent/config.rs
+++ b/crates/store/src/agent/config.rs
@@ -61,6 +61,15 @@ pub struct AgentConfig {
     /// [`AgentConfig::token_budget`].
     #[serde(default = "default_thinking_budget")]
     pub thinking_budget: u32,
+    /// The model's context window, when it is known.
+    ///
+    /// Nothing the runtime reaches carries one: `ModelInfo` on the wire is
+    /// a name and whether it is active, and a provider's catalogue is a
+    /// list of names. So a client that wants to act before a call stops
+    /// fitting — compacting rather than failing — is told the number here
+    /// or does not act at all.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_window: Option<u32>,
     /// Skill names this agent can access. Empty = all skills (crabtalk default).
     #[serde(default)]
     pub skills: Vec<String>,
@@ -159,6 +168,7 @@ impl Default for AgentConfig {
             thinking: false,
             max_tokens: crabllm_core::anthropic::DEFAULT_MAX_TOKENS,
             thinking_budget: DEFAULT_THINKING_BUDGET,
+            context_window: None,
             skills: Vec::new(),
             harnesses: Vec::new(),
             mcps: Vec::new(),

--- a/crates/store/src/interface/harness.rs
+++ b/crates/store/src/interface/harness.rs
@@ -60,7 +60,11 @@ impl<T: KVStorage> Harnesses for T {
 }
 
 /// Content address for a harness image.
-fn digest(bytes: &[u8]) -> String {
+///
+/// Public because it is part of the contract rather than of this
+/// implementation: two backends that key the same bytes differently
+/// would each be right and still disagree.
+pub fn digest(bytes: &[u8]) -> String {
     // FNV-1a: berm keys images by digest only to tell "same image" from
     // "different image", and this store never sees an adversary that
     // picks the bytes — the daemon does not download code.

--- a/crates/store/src/interface/mod.rs
+++ b/crates/store/src/interface/mod.rs
@@ -14,7 +14,7 @@
 
 pub use agent::{Agents, validate_table_name};
 pub use event::{EventSubscription, Subscriptions};
-pub use harness::Harnesses;
+pub use harness::{Harnesses, digest};
 pub use memory::{Memory, MemoryEntry};
 pub use session::{Sessions, Weights};
 pub use skill::{Skill, SkillSummary, Skills};

--- a/crates/store/src/text.rs
+++ b/crates/store/src/text.rs
@@ -72,6 +72,29 @@ impl Default for Bm25 {
     }
 }
 
+impl Bm25 {
+    /// What a term appearing in `df` of `docs` documents is worth.
+    ///
+    /// A term in everything says nothing about which document is meant,
+    /// so it tends to zero; a rare one carries the query.
+    pub fn idf(&self, df: usize, docs: usize) -> f64 {
+        let (df, docs) = (df as f64, docs as f64);
+        ((docs - df + 0.5) / (df + 0.5) + 1.0).ln()
+    }
+
+    /// A term's contribution to the document holding it `tf` times,
+    /// against a document of `len` tokens where the average is `avgdl`.
+    ///
+    /// Public because a backend that keeps no inverted index still has to
+    /// rank the documents it scanned, and two implementations of the same
+    /// formula would rank the same query differently the first time one
+    /// of them was edited.
+    pub fn weigh(&self, tf: u32, len: u32, avgdl: f64) -> f64 {
+        let (tf, len) = (tf as f64, len as f64);
+        (tf * (self.k1 + 1.0)) / (tf + self.k1 * (1.0 - self.b + self.b * len / avgdl))
+    }
+}
+
 /// What is known about one indexed document.
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct Doc {
@@ -223,14 +246,13 @@ impl<T: KVStorage> TextSearch for T {
         if stats.docs == 0 {
             return Ok(Vec::new());
         }
-        let n = stats.docs as f64;
-        let avgdl = stats.total_len as f64 / n;
-        let Bm25 { k1, b } = Bm25::default();
+        let avgdl = stats.total_len as f64 / stats.docs as f64;
+        let bm25 = Bm25::default();
 
         // term → postings, then postings → scores. Documents are
         // read once each, after the terms have named them all.
         let mut scores: HashMap<Vec<u8>, f64> = HashMap::new();
-        let mut lens: HashMap<Vec<u8>, (f64, f64)> = HashMap::new();
+        let mut lens: HashMap<Vec<u8>, (u32, f64)> = HashMap::new();
         for term in &terms {
             let postings = self.postings(index, term).await?;
             if postings.is_empty() {
@@ -238,8 +260,7 @@ impl<T: KVStorage> TextSearch for T {
             }
             // A prefix's document frequency is the union it matches,
             // which is what makes a broad prefix weigh less.
-            let df = postings.len() as f64;
-            let idf = ((n - df + 0.5) / (df + 0.5) + 1.0).ln();
+            let idf = bm25.idf(postings.len(), stats.docs as usize);
             for (key, tf) in postings {
                 let (dl, weight) = match lens.get(&key) {
                     Some(known) => *known,
@@ -248,14 +269,12 @@ impl<T: KVStorage> TextSearch for T {
                             .get_json::<Doc>(Column::Text, &self.doc_key(index, &key))
                             .await?
                             .unwrap_or_default();
-                        let known = (doc.len as f64, doc.weight);
+                        let known = (doc.len, doc.weight);
                         lens.insert(key.clone(), known);
                         known
                     }
                 };
-                let tf = tf as f64;
-                let norm = (tf * (k1 + 1.0)) / (tf + k1 * (1.0 - b + b * dl / avgdl));
-                *scores.entry(key).or_insert(0.0) += idf * norm * weight;
+                *scores.entry(key).or_insert(0.0) += idf * bm25.weigh(tf, dl, avgdl) * weight;
             }
         }
 

--- a/docs/src/arch.md
+++ b/docs/src/arch.md
@@ -8,7 +8,7 @@ turn out to be arguments about which one someone means.
 
 ```
 protocol     clients, over a socket    any language, untrusted
-harness      what shapes an agent      declared per agent, one source, two builds
+harness      what shapes an agent      declared per agent, sandboxed or compiled in
 capability   what an agent reaches     bounded by its argument
 runtime      lifetime orchestration    turns, conversations, the agent loop
 store        data                      one key-value primitive, everything above it free
@@ -23,40 +23,38 @@ agent — an agent *is* its harnesses.
 
 A **capability** is a mechanism for reaching something that is not the agent:
 `fs` and `exec` for the machine, `http` for the network, MCP for other
-software. Calling another program is not shaping an agent, which is why MCP is
-a capability and never a harness.
+software, and `berm.call` for another harness.
 
-The **protocol** has capability groups because clients are outside the process
-entirely, and a harness reaching back through `crabtalk.protocol.call` is
-holding a client's surface. It stays exported whether or not anything shipped
-here uses it — who *may* write a harness justifies it, not who does.
+The **protocol** is what clients speak over the socket. A harness reaches the
+runtime through one capability per operation instead — `peers`, `sessions`,
+`skills` — each narrowing by existing rather than by a check run over a decoded
+message. `sessions::search` cannot name an agent because it takes a search and
+returns hits, and there is no field in it to mean anything else.
 
 `runtime` owns the *architecture of lifetime* — turns, conversations, the
 agent loop — and nothing else. `store` owns the data, and owns it behind a
 single primitive: implement five key-value methods and every interface above
 them — agents, sessions, memory, skills, harnesses, search — comes for free.
 
-## One source, two builds
+## Sandboxed and compiled in
 
-A harness is one crate compiled two ways. Built `no_std` for RV64 it is a
-sandboxed ELF the daemon schedules, reaching the world only through
-capabilities its declaration bounded — the absence of a capability from its
-linker *is* the enforcement. Built with `std` it is compiled into the host and
-reaches those things directly.
+A harness **image** is `no_std` for RV64 and nothing else: a sandboxed ELF the
+daemon schedules, reaching the world only through capabilities its declaration
+bounded — the absence of a capability from its linker *is* the enforcement.
+There is no `std` build of one. Off its target the crate still compiles, so
+`cargo test` can run the tools natively, but the capabilities there are
+`berm-lang` stubs a test arranges rather than anything that reaches out.
 
-So compiled-in versus sandboxed is a build target, not an architecture, and
-`Harness` is the one name for both. What differs is confinement: as an ELF the
-declaration's arguments bound it; compiled in there is no linker to omit from,
-and the same arguments are documentation. That follows from compiling something in
-being total trust — but it is one source under two security models, which is
-worth knowing before choosing a build.
+A **compiled-in** harness is native Rust inside the daemon, with the whole of
+`std`. MCP and memory are the two. It shares the `Harness` trait with an image
+and nothing else — not the source, not the confinement: there is no linker to
+omit from, so what bounds it is what it was written to do.
 
-`no_std` is the shared denominator rather than a floor. The compiled-in build
-inherits the sandbox's constraints instead of escaping them: sync, allocating
-through `alloc`. Anything that must keep state alive between invocations cannot
-make the trip, because a harness gets a fresh heap every call and persists
-through `fs` like anything else. MCP holds live connections, so MCP is compiled
-in and only compiled in — the same test, not a second one.
+So the two are different kinds rather than two builds of one thing, and what
+decides which a feature can be is state. An image gets a fresh heap every
+invocation and persists through `fs` like anything else, so anything holding
+something alive between calls cannot be one. MCP holds live connections; MCP is
+compiled in and only compiled in.
 
 ## Where does a thing go?
 
@@ -71,18 +69,18 @@ it is a harness and never a message.
 **2. Does it shape the agent, or reach past it?** What an agent remembers,
 loads, and knows of its own history shapes it — that is a harness, declared by
 the agents that want it. A mechanism for touching something outside is a
-capability, granted and bounded by its argument.
+capability, bounded by its argument.
 
 **3. Does it hold anything alive between calls?** If yes it can only be
-compiled in, because the sandboxed build gets a fresh heap per invocation.
-Persisting through `fs` does not count — a file outlives the call. A live
-connection does not.
+compiled in, because an image gets a fresh heap per invocation. Persisting
+through `fs` does not count — a file outlives the call. A live connection does
+not.
 
 ## Arguments, not lists
 
 The recurring rule, and the one worth defending hardest:
 
-> **The argument is the grant. A capability without one is never registered.**
+> **The argument is the capability. Without one it is never registered.**
 
 `root` is the argument to `fs` and `exec`; `hosts` is the argument to `http`.
 An under-specified declaration reaches *nothing* rather than everything, and

--- a/docs/src/rfcs/0205-berm.md
+++ b/docs/src/rfcs/0205-berm.md
@@ -11,6 +11,8 @@
 
 > **Updated (2026-08-22).** The sandbox left, which this RFC said it would: berm is [crabtalk/berm](https://github.com/crabtalk/berm) and reaches this repository from crates.io as `berm` and `berm-lang`. Every `berm/*` path below names a directory that is no longer here, and the layout it describes is upstream's to keep. What stays is `crates/berm` — crabtalk's side, unchanged.
 
+> **Updated (2026-08-24).** Two things this RFC designed are gone, and one it ruled out has landed. The per-harness allowlist over message types — `protocol:read`, `protocol:sessions`, one capability number carrying the whole surface — was removed: the runtime is reached through one capability per operation, and a capability the declaration did not bound is absent from the linker rather than refused on decode. The word *grant* went with it; the argument bounding a capability is the whole of it, and there is no list beside it. And "Can a harness call another deployed harness?" is answered yes: `berm.call` resolves a name per call against the declaring agent's own resolution, which is why the session is now part of an image's digest.
+
 > **Updated by [0207 (Store)](0207-store.md) (2026-08-18).** The `crates/hooks` paths cited below are gone — hooks were deleted as a crate, the internal `Hook` seam this RFC scoped out is now `Harness`, and its lifecycle methods were renamed (0207 supersedes 0075). Harness images have a home in the store as `image/{digest}`, but berm still reads them from `HARNESSES_DIR` on the filesystem; wiring it to the `Harnesses` interface is open work.
 
 ## Summary

--- a/docs/src/spec/daemon.md
+++ b/docs/src/spec/daemon.md
@@ -8,10 +8,10 @@ The daemon owns:
 
 - **Transports** — UDS and TCP listeners. Listening endpoints belong to the daemon, not to individual clients or agents.
 - **Runtime** — a single shared runtime instance behind `RwLock`. Agents share the runtime; the runtime is never cloned per conversation.
-- **Harnesses** — the composite `Harness`. Two ship today: the one surfacing the tools of each agent's declared harnesses, and MCP. `Harness` is public API at the runtime layer, so an embedder registers their own.
+- **Harnesses** — the composite `Harness`. Three ship today: the one surfacing the tools of each agent's declared harness images, MCP, and memory. `Harness` is public API at the runtime layer, so an embedder registers their own.
 - **Event bus** — subscription table and fire callback. File-backed by `events/subscriptions.toml` under the config directory.
 - **MCP handler** — connections to external MCP servers and routing to the tools they advertise.
-- **Harness images** — compiled RV64 ELFs, keyed by a content digest of the ELF, its grants, and the scope its capabilities close over.
+- **Harness images** — compiled RV64 ELFs, keyed by a content digest of the ELF, the arguments bounding its capabilities, the session it resolved under, and the scope those capabilities close over.
 - **Configuration** — current `DaemonConfig`, reloaded in place on explicit reload.
 
 The daemon does not interpret tool semantics. Tool dispatch is the runtime's responsibility, routed through the composite.

--- a/docs/src/spec/harness.md
+++ b/docs/src/spec/harness.md
@@ -2,7 +2,7 @@
 
 A harness is code the daemon schedules: one hash-pinned RV64IMAC ELF, compiled
 and run in-process, confined to its own address space, reaching the world only
-through host calls it was granted. It never runs of its own accord — the daemon
+through host calls it was given. It never runs of its own accord — the daemon
 decides when, and while running it may call back in.
 
 A harness is what shapes an agent — what it remembers, what it can load, what
@@ -10,20 +10,20 @@ it knows of its own past, the tools it habitually reaches for. An agent *is*
 its harnesses, which is why each one is declared per agent rather than shipped
 to everybody.
 
-This chapter describes the sandboxed build. The same source compiled with `std`
-is the same harness reaching the host directly; see
-[Architecture](../arch.md).
+This chapter describes harness images. The daemon also carries compiled-in
+harnesses — MCP and memory — which share the trait and none of the
+confinement; see [Architecture](../arch.md).
 
-## The argument is the grant
+## The argument is the capability
 
-Host functions are keyed by number, and a number with nothing registered traps.
-So a capability the declaration did not bound is not *checked for* — it is
-absent from the linker the harness was instantiated with. **Enforcement is the
-absence of code.** There is no check to write and none to forget.
+Host calls are keyed by number, and a number with nothing registered traps. So
+a capability the declaration did not bound is not *checked for* — it is absent
+from the linker the harness was instantiated with. **Enforcement is the absence
+of code.** There is no check to write and none to forget.
 
 Every capability takes an argument, and the argument is not optional decoration
-— it *is* the grant. Without the argument the capability is never registered,
-so an under-specified declaration reaches **nothing** rather than everything.
+— it *is* the capability. Without the argument it is never registered, so an
+under-specified declaration reaches **nothing** rather than everything.
 
 | Capability | Reaches | Bounded by |
 |------------|---------|------------|
@@ -33,17 +33,30 @@ so an under-specified declaration reaches **nothing** rather than everything.
 | `peers` | The other agents' names | — |
 | `sessions` | The agent's own past conversations | the declaring agent |
 | `skills` | The skills the agent named | `skills` |
+| `berm.call` | Another harness the same agent declared | the declaring agent |
 
-The runtime is reached through one door per operation rather than one door
-carrying every message. A door narrows by existing: `sessions::search` cannot
+The runtime is reached through one capability per operation rather than one
+carrying every message. Each narrows by existing: `sessions::search` cannot
 name an agent, because it takes a search and returns hits and there is no field
 in it to mean anything else.
 
-That is also why the daemon's own port is not a side door: `http` can only
+That is also why the daemon's own port is not a way back in: `http` can only
 reach a name written in `hosts`, so `localhost` is unreachable unless somebody
 put it there.
 
-## The image is the grant
+## Calling another harness
+
+`berm.call` takes a harness name, a tool, and the argument blob a model would
+have sent. The name is resolved per call against the declaring agent's own
+resolution, so what a name means is what that agent declared it to mean — two
+agents installing different images under one name reach their own.
+
+A caller can tell a target that ran and failed from one that never ran: the
+first is the tool's own failure, the second a refusal. There is no depth bound.
+The watchdog bounds a chain on time rather than on links, so a cycle reaches
+the host thread's stack first.
+
+## The image is the capability
 
 There is no list of permitted capabilities beside those arguments. A published
 harness is a fixed ELF: one that never calls a capability does not need to be
@@ -62,14 +75,19 @@ schema, and usage text out of the file without compiling anything.
 ## Images are content-addressed
 
 An image is keyed by a digest of what determines it: the ELF, the `root` and
-`hosts` bounding it, and the `Scope` its protocol door closes over. Not by the
-agent that declared it.
+`hosts` bounding it, the session it resolved under, and the `Scope` its runtime
+capabilities close over. Not by the agent that declared it.
 
 Two agents that declare the same ELF against different roots hash differently
 and get two linkers. Two that declare it identically share one image. A rename
 changes nothing, because the agent's name was never part of the key — but a
 per-agent narrowing *is* part of it, so two agents holding the same session
 harness deliberately get two images rather than sharing one narrowing.
+
+The session is in the key for `berm.call`, which closes over the resolution a
+name is looked up in. Only a session-rooted declaration reaches the bound
+`root`, so without it a rootless or fixed-root image would be shared across
+sessions while resolving its siblings against whichever one compiled it first.
 
 ## Invocation
 

--- a/docs/src/spec/protocol.md
+++ b/docs/src/spec/protocol.md
@@ -1,6 +1,6 @@
 # Protocol
 
-The protocol is the daemon's surface for everything outside its process. Clients speak it over a socket; a harness holding a `protocol:*` capability speaks the same one from inside a sandbox. There is no second vocabulary for harnesses.
+The protocol is the daemon's surface for everything outside its process. Clients speak it over a socket. A harness does not: it reaches the runtime through one capability per operation, and the host builds the `ClientMessage` on its behalf.
 
 ## Addressing
 
@@ -25,14 +25,15 @@ There is no working directory on the wire. `StreamMsg.cwd` was removed: the daem
 
 A client declares no tools either. `SendMsg.tools` and `StreamMsg.tools` carried schemas the daemon advertised to the model and invoked back over the stream; both are reserved field numbers now, along with the forward event and its reply. A tool runs where the runtime does, which is what a harness is for.
 
-## Capability groups
+## One capability per operation
 
-A harness reaches this surface through `crabtalk.protocol.call`, and what it may send is checked on decode against the group its declaration granted. The check is **default-deny**: a message type in no group reaches nothing, and a group the harness was not granted is the same.
+A harness reaches the runtime through a capability per operation — `peers::list`, `sessions::search`, `skills::list`, `skills::get` — rather than through one that carries any message. Each narrows by existing: `sessions::search` takes a search and returns hits, and there is no field in it that could name an agent or spend a token. Nothing is checked on decode, because there is nothing to decode a policy out of.
 
-- `protocol:read` — the catalogue, and nothing that spends tokens.
-- `protocol:sessions` — ranked excerpts of the declaring agent's own past conversations.
+Each also owns its reply, which is where narrowing lives. `peers::list` returns agents with `AgentInfo.config` cleared, because a config carries its MCPs by value — `env` and a literal `Authorization` header among them.
 
-Anything destructive, anything that answers on someone else's behalf, and anything whose payload is substantially a credential belongs to no group a third party can hold. Where a request carries a scope the harness should not choose — `SearchSessions.agent` — the host **overwrites** it rather than validating it. Refusing a wrong value would only teach the harness to send the right one.
+Where a request carries a scope the harness should not choose — `SearchSessions.agent` — the host **overwrites** it rather than validating it. Refusing a wrong value would only teach the harness to send the right one.
+
+Anything destructive, and anything that answers on someone else's behalf, is behind no capability at all. Reaching another agent is a turn spent on its behalf, so `peers` names them and stops there.
 
 ## Transports
 
@@ -48,7 +49,7 @@ Concurrency is unbounded at this layer: nothing throttles or serializes incoming
 
 `Server::dispatch(ClientMessage) -> Stream<ServerMessage>` is the single entry into the daemon's operations. It inspects the `ClientMessage` variant and routes to the corresponding method on the `Server` trait.
 
-It is also the door a harness comes back through. A harness granted a `protocol:*` capability sends the same `ClientMessage` a client would and receives the same reply — one vocabulary, not two. What it is *allowed* to send is checked on decode against the group its declaration granted, and default-deny: a message named in no group reaches nothing.
+It is also what a harness comes back through, one remove away: a runtime capability builds the `ClientMessage` its operation means and takes the one reply, so the daemon answers a harness exactly as it answers a client. The harness supplies a search, not a message.
 
 - Request-response operations (`ping`, `kill_conversation`, `compact_conversation`, administrative calls) yield exactly one `ServerMessage`.
 - Streaming operations (`stream`, `subscribe_events`) yield many `ServerMessage` values over time.

--- a/docs/src/spec/runtime.md
+++ b/docs/src/spec/runtime.md
@@ -120,7 +120,7 @@ These belong to the server that hosts the runtime.
 - `subscribe_events()` — optional subscription to a cross-conversation event stream, for servers that expose agent events to external clients.
 Methods that the runtime does not need in a given context have default implementations. An `Env` implementation may leave event broadcasting at its default.
 
-Instruction discovery and working-directory resolution are not here. The daemon does not read the user's filesystem — a client renders local instructions into the message it sends, and a harness reaches files through the root its declaration grants.
+Instruction discovery and working-directory resolution are not here. The daemon does not read the user's filesystem — a client renders local instructions into the message it sends, and a harness reaches files through the root its declaration names.
 
 ## Harness
 

--- a/harness/os/README.md
+++ b/harness/os/README.md
@@ -1,7 +1,7 @@
 # berm-os
 
-`bash`, `read`, `edit`, `glob` and `grep` as a harness. Grants `fs` and `exec`,
-both bounded by `root`. Searching honours `.gitignore`.
+`bash`, `read`, `edit`, `glob` and `grep` as a harness. Reaches the machine
+through `fs` and `exec`, both bounded by `root`. Searching honours `.gitignore`.
 
 ```sh
 cargo test -p berm-os    # tools run natively, no RISC-V toolchain

--- a/harness/peers/README.md
+++ b/harness/peers/README.md
@@ -1,7 +1,7 @@
 # berm-peers
 
-Names the other agents in the runtime. One tool, one door: `peers::list`, which
-answers without the configs that carry their credentials.
+Names the other agents in the runtime. One tool, one capability: `peers::list`,
+which answers without the configs that carry their credentials.
 
 ```sh
 cargo test -p berm-peers

--- a/lib/berm/README.md
+++ b/lib/berm/README.md
@@ -1,14 +1,14 @@
 # berm-crabtalk
 
-The guest half of the `crabtalk` namespace: `fs`, `exec`, `http`, and one door
-per runtime operation — `peers`, `sessions`, `skills`. A harness links this to
-reach a Crabtalk daemon; [`crabtalk-berm`](../../crates/berm) serves the other
-end of every name in it.
+The guest half of the `crabtalk` namespace: `fs`, `exec`, `http`, and one
+capability per runtime operation — `peers`, `sessions`, `skills`. A harness
+links this to reach a Crabtalk daemon; [`crabtalk-berm`](../../crates/berm)
+serves the other end of every name in it.
 
 ```rust
 let agents = protocol::peers()?;              // the other agents
 let body = protocol::skill("review")?;        // one skill's instructions
-let bytes = fs::read("src/lib.rs")?;          // inside the granted root
+let bytes = fs::read("src/lib.rs")?;          // inside the root it was given
 ```
 
 [`berm-lang`](https://crates.io/crates/berm-lang) owns the ABI and declares no


### PR DESCRIPTION
## What

`crab` — a terminal coding agent that embeds the runtime in its own process. No daemon, no socket. `crab -p <text>` runs one turn and prints the answer for piping.

## How

A file-backed store owned by the app: the six `Backend` interfaces implemented directly, a session as a directory of JSONL. That partition is what lets two `crab` processes write at once, which crabdb cannot.

An inline TUI, not full-screen: the viewport holds what is unfinished, scrollback holds what is final. Items keep their source, not their rendering, so resize reflow can follow.

Compaction triggers where the next call stops fitting — `prompt_tokens + token_budget() >= context_window` — rather than at a chosen fraction. The window is new on `AgentConfig` because nothing the runtime reaches carries one.

## State

No turn has completed end to end: my endpoint answers 502/404, so the response path is unexercised. The store, session creation, the system prompt, and the daemon's store relocation are each verified by running them.

Deliberate for now: the viewport is a fixed 8 rows (ratatui cannot resize an inline one), no slash completions, and a repo outside `$HOME` is refused.
